### PR TITLE
Add configurable Bluetooth adapter selection

### DIFF
--- a/bluetooth_audio_manager/config.yaml
+++ b/bluetooth_audio_manager/config.yaml
@@ -1,5 +1,5 @@
 name: "Bluetooth Audio Manager"
-version: "0.1.60"
+version: "0.1.61"
 slug: bluetooth_audio_manager
 description: "Manage Bluetooth audio device connections (A2DP) with persistent pairing, auto-reconnect, and AppArmor security."
 url: "https://github.com/scyto/ha-bluetooth-audio-manager"
@@ -40,6 +40,7 @@ options:
   keep_alive_enabled: false
   keep_alive_method: "infrasound"
   scan_duration_seconds: 30
+  bt_adapter: "auto"
 
 schema:
   log_level: "list(debug|info|warning|error)"
@@ -49,6 +50,7 @@ schema:
   keep_alive_enabled: bool
   keep_alive_method: "list(silence|infrasound)"
   scan_duration_seconds: "int(5,60)"
+  bt_adapter: "str"
 
 apparmor: true
 watchdog: "http://[HOST]:[PORT:8099]/api/health"

--- a/bluetooth_audio_manager/rootfs/usr/src/bt_audio_manager/bluez/device.py
+++ b/bluetooth_audio_manager/rootfs/usr/src/bt_audio_manager/bluez/device.py
@@ -11,6 +11,7 @@ from dbus_next.errors import DBusError
 
 from .constants import (
     BLUEZ_SERVICE,
+    DEFAULT_ADAPTER_PATH,
     DEVICE_INTERFACE,
     PROPERTIES_INTERFACE,
 )
@@ -20,7 +21,7 @@ logger = logging.getLogger(__name__)
 MEDIA_PLAYER_INTERFACE = "org.bluez.MediaPlayer1"
 
 
-def address_to_path(address: str, adapter_path: str = "/org/bluez/hci0") -> str:
+def address_to_path(address: str, adapter_path: str = DEFAULT_ADAPTER_PATH) -> str:
     """Convert a MAC address to a BlueZ D-Bus object path."""
     return f"{adapter_path}/dev_{address.replace(':', '_')}"
 
@@ -28,7 +29,7 @@ def address_to_path(address: str, adapter_path: str = "/org/bluez/hci0") -> str:
 class BluezDevice:
     """Wraps org.bluez.Device1 for pairing, connecting, and monitoring a device."""
 
-    def __init__(self, bus: MessageBus, address: str, adapter_path: str = "/org/bluez/hci0"):
+    def __init__(self, bus: MessageBus, address: str, adapter_path: str = DEFAULT_ADAPTER_PATH):
         self._bus = bus
         self._address = address
         self._path = address_to_path(address, adapter_path)

--- a/bluetooth_audio_manager/rootfs/usr/src/bt_audio_manager/config.py
+++ b/bluetooth_audio_manager/rootfs/usr/src/bt_audio_manager/config.py
@@ -25,6 +25,21 @@ class AppConfig:
     keep_alive_enabled: bool = False
     keep_alive_method: str = "infrasound"
     scan_duration_seconds: int = 15
+    bt_adapter: str = "auto"
+
+    @property
+    def adapter_path(self) -> str:
+        """Resolve the bt_adapter setting to a BlueZ D-Bus adapter path.
+
+        "auto" → "/org/bluez/hci0" (default first adapter).
+        "hci1" → "/org/bluez/hci1", etc.
+        """
+        if self.bt_adapter == "auto":
+            return "/org/bluez/hci0"
+        name = self.bt_adapter
+        if name.startswith("/org/bluez/"):
+            return name
+        return f"/org/bluez/{name}"
 
     @classmethod
     def load(cls) -> "AppConfig":
@@ -44,6 +59,7 @@ class AppConfig:
                 keep_alive_enabled=data.get("keep_alive_enabled", False),
                 keep_alive_method=data.get("keep_alive_method", "infrasound"),
                 scan_duration_seconds=data.get("scan_duration_seconds", 15),
+                bt_adapter=data.get("bt_adapter", "auto"),
             )
         except (json.JSONDecodeError, KeyError) as e:
             logger.error("Failed to parse options: %s, using defaults", e)

--- a/bluetooth_audio_manager/rootfs/usr/src/bt_audio_manager/web/api.py
+++ b/bluetooth_audio_manager/rootfs/usr/src/bt_audio_manager/web/api.py
@@ -69,11 +69,24 @@ def create_api_routes(manager: "BluetoothAudioManager") -> list[web.RouteDef]:
 
     @routes.get("/api/info")
     async def info(request: web.Request) -> web.Response:
-        """Return add-on version info for the UI."""
+        """Return add-on version and adapter info for the UI."""
         import os
+        adapter_name = manager._adapter_path.rsplit("/", 1)[-1]
         return web.json_response({
             "version": os.environ.get("BUILD_VERSION", "dev"),
+            "adapter": adapter_name,
+            "adapter_path": manager._adapter_path,
         })
+
+    @routes.get("/api/adapters")
+    async def list_adapters(request: web.Request) -> web.Response:
+        """List all Bluetooth adapters on the system."""
+        try:
+            adapters = await manager.list_adapters()
+            return web.json_response({"adapters": adapters})
+        except Exception as e:
+            logger.error("Failed to list adapters: %s", e)
+            return web.json_response({"error": str(e)}, status=500)
 
     @routes.get("/api/devices")
     async def list_devices(request: web.Request) -> web.Response:

--- a/bluetooth_audio_manager/rootfs/usr/src/bt_audio_manager/web/static/index.html
+++ b/bluetooth_audio_manager/rootfs/usr/src/bt_audio_manager/web/static/index.html
@@ -55,6 +55,13 @@
       </div>
     </section>
 
+    <section id="adapters-section">
+      <h2>Bluetooth Adapters</h2>
+      <div id="adapters-list" class="adapters-list">
+        <p class="placeholder">Loading adapter info...</p>
+      </div>
+    </section>
+
     <footer class="app-footer">
       <span id="version-label"></span>
     </footer>


### PR DESCRIPTION
## Summary
- Adds `bt_adapter` config option so users can dedicate a specific BT adapter (e.g. `hci1`) to this add-on, while HAOS keeps its adapter for BLE scanning
- New `/api/adapters` endpoint lists all system adapters with their status (powered, discovering/BLE scanning, selected)
- Adapter info shown in the UI — identifies which adapter is selected and which is doing HA BLE scanning
- All BlueZ operations (adapter, device, media player) now use the configured adapter path instead of hardcoding `hci0`

## Files changed
- `config.yaml` — new `bt_adapter` option (default: `"auto"` = hci0)
- `config.py` — `bt_adapter` field + `adapter_path` property
- `adapter.py` — `list_all()` static method to enumerate all adapters
- `device.py` — use `DEFAULT_ADAPTER_PATH` constant instead of hardcoded string
- `media_player.py` — accept `adapter_path` parameter
- `manager.py` — thread `adapter_path` through all component creation
- `api.py` — `/api/adapters` endpoint, adapter name in `/api/info`
- `app.js` / `index.html` — adapter listing UI section, adapter name in footer

## Test plan
- [ ] Verify default behavior (`bt_adapter: "auto"`) still uses hci0
- [ ] Verify `/api/adapters` returns correct list of adapters with properties
- [ ] Test with `bt_adapter: "hci1"` to confirm add-on uses the second adapter
- [ ] Verify HA BLE scanning detection (Discovering=true on non-selected adapter)
- [ ] Confirm all device operations (pair, connect, disconnect, forget) use the configured adapter

🤖 Generated with [Claude Code](https://claude.com/claude-code)