### PR TITLE
Enrich adapter names from HA Supervisor hardware API

### DIFF
--- a/bluetooth_audio_manager/config.yaml
+++ b/bluetooth_audio_manager/config.yaml
@@ -1,5 +1,5 @@
 name: "Bluetooth Audio Manager"
-version: "0.1.63"
+version: "0.1.64"
 slug: bluetooth_audio_manager
 description: "Manage Bluetooth audio device connections (A2DP) with persistent pairing, auto-reconnect, and AppArmor security."
 url: "https://github.com/scyto/ha-bluetooth-audio-manager"


### PR DESCRIPTION
## Summary
- Inside Docker containers, sysfs is not accessible so adapter names fall back to raw Modalias strings (e.g. `usb:v1D6Bp0246d0555`) instead of human-readable names
- Now queries the HA Supervisor `/hardware/info` API to get real USB device names (manufacturer + product), matching what HAOS displays
- Matches adapters by hci name from sysfs path in Supervisor data, and by USB vendor:product from Modalias
- Logs raw Supervisor device data when no matches found for debugging

## Test plan
- [ ] Verify adapter cards show human-readable USB device names instead of raw Modalias
- [ ] Check add-on logs for `Supervisor HW names:` to confirm matching worked

🤖 Generated with [Claude Code](https://claude.com/claude-code)