### PR TITLE
Fix AVRCP volume control after add-on restart

### DIFF
--- a/bluetooth_audio_manager/config.yaml
+++ b/bluetooth_audio_manager/config.yaml
@@ -1,5 +1,5 @@
 name: "Bluetooth Audio Manager"
-version: "0.1.65"
+version: "0.1.66"
 slug: bluetooth_audio_manager
 description: "Manage Bluetooth audio device connections (A2DP) with persistent pairing, auto-reconnect, and AppArmor security."
 url: "https://github.com/scyto/ha-bluetooth-audio-manager"

--- a/bluetooth_audio_manager/rootfs/usr/src/bt_audio_manager/bluez/device.py
+++ b/bluetooth_audio_manager/rootfs/usr/src/bt_audio_manager/bluez/device.py
@@ -67,6 +67,11 @@ class BluezDevice:
         self._avrcp_last_search = 0.0
         logger.debug("Device %s cleaned up", self._address)
 
+    def reset_avrcp_watch(self) -> None:
+        """Clear AVRCP subscription state so watch_media_player() will re-search."""
+        self._player_path = None
+        self._avrcp_last_search = 0.0
+
     def _on_properties_changed(
         self, interface_name: str, changed: dict, invalidated: list
     ) -> None:


### PR DESCRIPTION
## Summary
- **Remove counterproductive MPRIS re-registration** from `_renegotiate_a2dp()` — the post-reconnect unregister/re-register was severing the `MediaControl1.Player` link that BlueZ established during `ConnectProfile`, breaking absolute volume while passthrough commands (Next/Prev) still worked.
- **Add AVRCP session refresh at startup** for already-connected devices — when the add-on restarts, the old D-Bus unique name is gone but the AVRCP session still references it. New `_refresh_avrcp_session()` cycles AVRCP target/controller profiles without tearing down A2DP audio, forcing BlueZ to rebind the control channel to the new process's MPRIS player. This eliminates the need for the disruptive full-disconnect renegotiation the 15-second diagnostic was triggering.

## Test plan
- [ ] Deploy and restart the add-on with a speaker already connected
- [ ] Verify log shows AVRCP profile cycling at startup (`DisconnectProfile` / `ConnectProfile` for AVRCP UUIDs)
- [ ] Verify `MediaControl1 for ...: Connected=True Player=/org/ha/bluetooth_audio/player` appears
- [ ] Verify no "DIAG: No AVRCP volume signal" renegotiation trigger fires
- [ ] Test hardware volume buttons — `AVRCP transport volume` log entries should appear
- [ ] Test Next/Prev buttons — `MPRIS command` log entries should appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)