### PR TITLE
Add btmon startup capture for AVRCP diagnostics

### DIFF
--- a/bluetooth_audio_manager/Dockerfile
+++ b/bluetooth_audio_manager/Dockerfile
@@ -2,6 +2,7 @@ ARG BUILD_FROM=ghcr.io/home-assistant/amd64-base:3.20
 FROM ${BUILD_FROM}
 
 RUN apk add --no-cache \
+    bluez \
     bluez-libs \
     dbus-libs \
     pulseaudio-utils \
@@ -22,7 +23,8 @@ RUN chmod +x /init \
     && chmod +x /etc/s6-overlay/s6-rc.d/bt-audio-manager/run \
     && chmod +x /etc/s6-overlay/s6-rc.d/bt-audio-manager/finish \
     && chmod +x /etc/cont-init.d/01-verify-dbus.sh \
-    && chmod +x /etc/cont-init.d/02-init-storage.sh
+    && chmod +x /etc/cont-init.d/02-init-storage.sh \
+    && chmod +x /etc/cont-init.d/03-btmon-capture.sh
 
 ENV PYTHONPATH="/usr/src"
 

--- a/bluetooth_audio_manager/config.yaml
+++ b/bluetooth_audio_manager/config.yaml
@@ -1,5 +1,5 @@
 name: "Bluetooth Audio Manager"
-version: "0.1.66"
+version: "0.1.67"
 slug: bluetooth_audio_manager
 description: "Manage Bluetooth audio device connections (A2DP) with persistent pairing, auto-reconnect, and AppArmor security."
 url: "https://github.com/scyto/ha-bluetooth-audio-manager"

--- a/bluetooth_audio_manager/rootfs/etc/cont-init.d/03-btmon-capture.sh
+++ b/bluetooth_audio_manager/rootfs/etc/cont-init.d/03-btmon-capture.sh
@@ -1,0 +1,17 @@
+#!/command/with-contenv bashio
+# shellcheck shell=bash
+# ==============================================================================
+# Start btmon capture for AVRCP diagnostics (runs for 90s at startup)
+# ==============================================================================
+
+BTMON_LOG="/data/btmon_startup.log"
+
+if command -v btmon >/dev/null 2>&1; then
+    bashio::log.info "Starting btmon capture to ${BTMON_LOG} (90s)..."
+    # Rotate previous capture
+    [ -f "${BTMON_LOG}" ] && mv "${BTMON_LOG}" "${BTMON_LOG}.prev"
+    # Run btmon in background, auto-kill after 90s
+    (timeout 90 btmon 2>&1 | head -n 5000 > "${BTMON_LOG}") &
+else
+    bashio::log.warning "btmon not found — install 'bluez' package for AVRCP diagnostics"
+fi


### PR DESCRIPTION
## Summary
- Install full `bluez` package (includes btmon binary) in the Docker image
- Add init script that captures 90 seconds of HCI monitor output to `/data/btmon_startup.log` at every add-on start
- Captures the AVRCP capability exchange during startup and profile cycling to diagnose why absolute volume isn't being negotiated after restart

## Test plan
- [ ] Deploy and check add-on log for "Starting btmon capture" message
- [ ] After startup, verify `/data/btmon_startup.log` exists and contains HCI traffic
- [ ] If btmon is blocked by AppArmor, adjust the profile to allow `network bluetooth` socket access

🤖 Generated with [Claude Code](https://claude.com/claude-code)