### PR TITLE
Add bluez-btmon package for HCI monitor capture

### DIFF
--- a/bluetooth_audio_manager/Dockerfile
+++ b/bluetooth_audio_manager/Dockerfile
@@ -3,6 +3,7 @@ FROM ${BUILD_FROM}
 
 RUN apk add --no-cache \
     bluez \
+    bluez-btmon \
     bluez-libs \
     dbus-libs \
     pulseaudio-utils \

--- a/bluetooth_audio_manager/config.yaml
+++ b/bluetooth_audio_manager/config.yaml
@@ -1,5 +1,5 @@
 name: "Bluetooth Audio Manager"
-version: "0.1.67"
+version: "0.1.68"
 slug: bluetooth_audio_manager
 description: "Manage Bluetooth audio device connections (A2DP) with persistent pairing, auto-reconnect, and AppArmor security."
 url: "https://github.com/scyto/ha-bluetooth-audio-manager"


### PR DESCRIPTION
## Summary
- Add `bluez-btmon` Alpine package to Dockerfile — btmon is a separate subpackage from `bluez` on Alpine

## Test plan
- [ ] Rebuild and verify `which btmon` returns `/usr/bin/btmon` inside the container
- [ ] Verify `/data/btmon_startup.log` is created on startup with HCI capture data

🤖 Generated with [Claude Code](https://claude.com/claude-code)