### PR TITLE
Enable host_network for btmon diagnostics

### DIFF
--- a/bluetooth_audio_manager/config.yaml
+++ b/bluetooth_audio_manager/config.yaml
@@ -1,5 +1,5 @@
 name: "Bluetooth Audio Manager"
-version: "0.1.68"
+version: "0.1.69"
 slug: bluetooth_audio_manager
 description: "Manage Bluetooth audio device connections (A2DP) with persistent pairing, auto-reconnect, and AppArmor security."
 url: "https://github.com/scyto/ha-bluetooth-audio-manager"
@@ -15,6 +15,7 @@ boot: auto
 
 # Permissions (least privilege)
 host_dbus: true
+host_network: true
 audio: true
 privileged:
   - NET_ADMIN


### PR DESCRIPTION
## Summary
- Add `host_network: true` to give the container access to AF_BLUETOOTH sockets needed by btmon
- Docker containers don't expose Bluetooth sockets by default, so btmon was failing with "Address family not supported by protocol"

**NOTE:** `host_network` should be removed after AVRCP diagnostics are complete.

## Test plan
- [ ] Rebuild and run `timeout 10 btmon` inside the container — should show HCI traffic
- [ ] Restart the add-on and verify `/data/btmon_startup.log` is created with capture data
- [ ] Verify ingress UI still works with host networking

🤖 Generated with [Claude Code](https://claude.com/claude-code)