### PR TITLE
Fix btmon startup capture script

### DIFF
--- a/bluetooth_audio_manager/config.yaml
+++ b/bluetooth_audio_manager/config.yaml
@@ -1,5 +1,5 @@
 name: "Bluetooth Audio Manager"
-version: "0.1.69"
+version: "0.1.70"
 slug: bluetooth_audio_manager
 description: "Manage Bluetooth audio device connections (A2DP) with persistent pairing, auto-reconnect, and AppArmor security."
 url: "https://github.com/scyto/ha-bluetooth-audio-manager"

--- a/bluetooth_audio_manager/rootfs/etc/cont-init.d/03-btmon-capture.sh
+++ b/bluetooth_audio_manager/rootfs/etc/cont-init.d/03-btmon-capture.sh
@@ -10,8 +10,8 @@ if command -v btmon >/dev/null 2>&1; then
     bashio::log.info "Starting btmon capture to ${BTMON_LOG} (90s)..."
     # Rotate previous capture
     [ -f "${BTMON_LOG}" ] && mv "${BTMON_LOG}" "${BTMON_LOG}.prev"
-    # Run btmon in background, auto-kill after 90s
-    (timeout 90 btmon 2>&1 | head -n 5000 > "${BTMON_LOG}") &
+    # Run btmon directly to file, kill after 90s
+    timeout 90 btmon > "${BTMON_LOG}" 2>&1 &
 else
-    bashio::log.warning "btmon not found — install 'bluez' package for AVRCP diagnostics"
+    bashio::log.warning "btmon not found — install 'bluez-btmon' package for AVRCP diagnostics"
 fi


### PR DESCRIPTION
## Summary
- Fix btmon startup capture — write directly to file instead of piping through `head`, which was preventing output from being flushed to disk

## Test plan
- [ ] Rebuild, restart, and verify `/data/btmon_startup.log` exists with HCI capture data
- [ ] Check `grep -i avrcp /data/btmon_startup.log` shows AVRCP protocol traffic

🤖 Generated with [Claude Code](https://claude.com/claude-code)