### PR TITLE
Bounce connection at startup to fix AVRCP absolute volume

### DIFF
--- a/bluetooth_audio_manager/config.yaml
+++ b/bluetooth_audio_manager/config.yaml
@@ -1,5 +1,5 @@
 name: "Bluetooth Audio Manager"
-version: "0.1.70"
+version: "0.1.71"
 slug: bluetooth_audio_manager
 description: "Manage Bluetooth audio device connections (A2DP) with persistent pairing, auto-reconnect, and AppArmor security."
 url: "https://github.com/scyto/ha-bluetooth-audio-manager"


### PR DESCRIPTION
## Summary
- btmon captures confirmed that only **speaker-initiated** reconnections trigger the full AVRCP `GetCapabilities` exchange including `EVENT_VOLUME_CHANGED` registration — BlueZ reuses stale cached AVRCP state when we initiate
- Replace `_refresh_avrcp_session()` at startup with `_bounce_for_avrcp()`: disconnects the device and waits up to 30s for the speaker to auto-reconnect, with `device.connect()` fallback
- Seeds `_last_signaled_volume` from transport after reconnect to prevent the diagnostic poller from triggering unnecessary renegotiation

## Test plan
- [ ] Restart the add-on with speaker already connected
- [ ] Log should show "AVRCP bounce: disconnecting..." followed by "reconnected after Ns (speaker-initiated)"
- [ ] Volume buttons should work immediately after bounce reconnect completes
- [ ] No "DIAG: No AVRCP volume signal" / renegotiation should trigger (volume seeded from transport)
- [ ] Test power-cycling the speaker — should still reconnect and work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)