### PR TITLE
Disconnect HFP after connect to fix volume buttons, upgrade BlueZ to …

### DIFF
--- a/bluetooth_audio_manager/Dockerfile
+++ b/bluetooth_audio_manager/Dockerfile
@@ -1,10 +1,13 @@
 ARG BUILD_FROM=ghcr.io/home-assistant/amd64-base:3.20
 FROM ${BUILD_FROM}
 
+# Pull bluez packages from Alpine edge to match HAOS host (5.85)
 RUN apk add --no-cache \
-    bluez \
-    bluez-btmon \
-    bluez-libs \
+    --repository=https://dl-cdn.alpinelinux.org/alpine/edge/main \
+    bluez~5.85 \
+    bluez-btmon~5.85 \
+    bluez-libs~5.85 \
+    && apk add --no-cache \
     dbus-libs \
     pulseaudio-utils \
     python3 \

--- a/bluetooth_audio_manager/config.yaml
+++ b/bluetooth_audio_manager/config.yaml
@@ -1,5 +1,5 @@
 name: "Bluetooth Audio Manager"
-version: "0.1.72"
+version: "0.1.73"
 slug: bluetooth_audio_manager
 description: "Manage Bluetooth audio device connections (A2DP) with persistent pairing, auto-reconnect, and AppArmor security."
 url: "https://github.com/scyto/ha-bluetooth-audio-manager"

--- a/bluetooth_audio_manager/rootfs/usr/src/bt_audio_manager/web/api.py
+++ b/bluetooth_audio_manager/rootfs/usr/src/bt_audio_manager/web/api.py
@@ -370,6 +370,21 @@ def create_api_routes(manager: "BluetoothAudioManager") -> list[web.RouteDef]:
             logger.error("debug_full_renegotiate failed for %s: %s", address, e)
             return web.json_response({"error": _friendly_error(e)}, status=500)
 
+    @routes.post("/api/debug/disconnect-hfp")
+    async def debug_disconnect_hfp(request: web.Request) -> web.Response:
+        """Debug: disconnect HFP profile to force AVRCP volume."""
+        address = None
+        try:
+            body = await request.json()
+            address = body.get("address")
+            if not address:
+                return web.json_response({"error": "address is required"}, status=400)
+            result = await manager.debug_disconnect_hfp(address)
+            return web.json_response(result)
+        except Exception as e:
+            logger.error("debug_disconnect_hfp failed for %s: %s", address, e)
+            return web.json_response({"error": _friendly_error(e)}, status=500)
+
     @routes.get("/api/diagnostics/mpris")
     async def diagnostics_mpris(request: web.Request) -> web.Response:
         """Diagnostic endpoint for MPRIS/AVRCP troubleshooting."""

--- a/bluetooth_audio_manager/rootfs/usr/src/bt_audio_manager/web/static/app.js
+++ b/bluetooth_audio_manager/rootfs/usr/src/bt_audio_manager/web/static/app.js
@@ -321,6 +321,17 @@ async function debugFullRenegotiate(address) {
   }
 }
 
+async function debugDisconnectHfp(address) {
+  try {
+    showStatus(`Disconnecting HFP on ${address}...`);
+    await apiPost("/api/debug/disconnect-hfp", { address });
+  } catch (e) {
+    showError(`Disconnect HFP failed: ${e.message}`);
+  } finally {
+    hideStatus();
+  }
+}
+
 function renderDebugActions(devices) {
   const container = $("#debug-actions");
   const placeholder = $("#debug-placeholder");
@@ -347,6 +358,7 @@ function renderDebugActions(devices) {
           <button class="btn btn-small btn-warning" onclick="debugMprisReregister('${d.address}')">MPRIS Re-register</button>
           <button class="btn btn-small btn-warning" onclick="debugMprisAvrcpCycle('${d.address}')">MPRIS+AVRCP Cycle</button>
           <button class="btn btn-small btn-danger" onclick="debugFullRenegotiate('${d.address}')">Full Renegotiate</button>
+          <button class="btn btn-small btn-primary" onclick="debugDisconnectHfp('${d.address}')">Disconnect HFP</button>
         </div>
       </div>
     `)


### PR DESCRIPTION
…5.85

Root cause: Bose (and many speakers) send volume button presses as HFP AT+VGS commands instead of AVRCP absolute volume. BlueZ doesn't map HFP volume to the A2DP MediaTransport, so volume buttons appear dead.

Fix: disconnect HFP profile after A2DP connects, forcing the speaker to fall back to AVRCP volume which BlueZ correctly propagates to MediaTransport1.Volume.

Also upgrades container BlueZ from 5.76 to 5.85 (Alpine edge) to match the HAOS host version, and adds a "Disconnect HFP" debug button.