### PR TITLE
Fix HFP volume issue and improve device resilience

### DIFF
--- a/bluetooth_audio_manager/config.yaml
+++ b/bluetooth_audio_manager/config.yaml
@@ -1,5 +1,5 @@
 name: "Bluetooth Audio Manager"
-version: "0.1.73"
+version: "0.1.74"
 slug: bluetooth_audio_manager
 description: "Manage Bluetooth audio device connections (A2DP) with persistent pairing, auto-reconnect, and AppArmor security."
 url: "https://github.com/scyto/ha-bluetooth-audio-manager"


### PR DESCRIPTION
## Summary

- **Root cause fix**: Bose speaker sends volume buttons as HFP `AT+VGS` commands instead of AVRCP absolute volume. Disconnecting HFP after A2DP connects forces the speaker to use AVRCP, which BlueZ correctly propagates to `MediaTransport1.Volume`
- **BlueZ upgrade**: Container BlueZ upgraded from 5.76 to 5.85 (matching HAOS host), picking up AVRCP volume fix from BlueZ 5.80
- **Device resilience**: All device operations now auto-create `BluezDevice` wrappers on demand via `_get_or_create_device()`, fixing silent failures when the device store gets wiped during rebuilds
- **Debug tooling**: AVRCP debug buttons for interactive testing, btmon startup capture moved to s6 run script

## Key changes

- `_disconnect_hfp()` called on all 3 connection paths (startup, manual connect, auto-reconnect)
- Startup enumerates connected BlueZ devices not in store and creates wrappers
- Dockerfile pulls BlueZ 5.85 from Alpine edge repo
- 5 debug buttons (AVRCP Cycle, MPRIS Re-register, MPRIS+AVRCP Cycle, Full Renegotiate, Disconnect HFP)
- btmon capture moved from cont-init.d to s6 run script (fixes permission issues)

## Test plan

- [ ] Deploy with speaker already connected — verify "Found connected device ... creating wrapper" in logs
- [ ] Press volume buttons on speaker — verify AVRCP volume events appear in UI
- [ ] Restart add-on — verify HFP auto-disconnected and volume buttons still work
- [ ] Test Disconnect/Forget buttons work even with empty device store
- [ ] Verify btmon startup capture creates `/data/btmon_startup.log`

🤖 Generated with [Claude Code](https://claude.com/claude-code)