### PR TITLE
Fix HFP volume, device resilience, disable harmful poll loop

### DIFF
--- a/bluetooth_audio_manager/config.yaml
+++ b/bluetooth_audio_manager/config.yaml
@@ -1,5 +1,5 @@
 name: "Bluetooth Audio Manager"
-version: "0.1.74"
+version: "0.1.75"
 slug: bluetooth_audio_manager
 description: "Manage Bluetooth audio device connections (A2DP) with persistent pairing, auto-reconnect, and AppArmor security."
 url: "https://github.com/scyto/ha-bluetooth-audio-manager"

--- a/bluetooth_audio_manager/rootfs/usr/src/bt_audio_manager/manager.py
+++ b/bluetooth_audio_manager/rootfs/usr/src/bt_audio_manager/manager.py
@@ -276,8 +276,8 @@ class BluetoothAudioManager:
         # 10. Start periodic sink state polling
         self._sink_poll_task = asyncio.create_task(self._sink_poll_loop())
 
-        # 11. Start diagnostic volume poller (detects BlueZ AVRCP volume signal loss)
-        self._volume_poll_task = asyncio.create_task(self._volume_poll_loop())
+        # Volume poll loop disabled — it triggers harmful renegotiations.
+        # HFP disconnect is the real fix for AVRCP volume.
 
         logger.info("Bluetooth Audio Manager started successfully")
 


### PR DESCRIPTION
## Summary

- **Root cause fix**: Bose speaker sends volume via HFP `AT+VGS` instead of AVRCP. Disconnecting HFP after A2DP connect forces AVRCP volume
- **BlueZ 5.85**: Container upgraded from 5.76 to match HAOS host, includes AVRCP volume fix from 5.80
- **Device resilience**: All operations auto-create `BluezDevice` wrappers on demand — fixes silent failures when device store gets wiped during rebuilds
- **Disabled volume poll loop**: Was triggering unnecessary disconnect/reconnect cycles via `_renegotiate_a2dp` after 15s with no volume signal
- **Debug tooling**: AVRCP debug buttons + btmon startup capture

## Commits

- `036079f` Bounce connection at startup (superseded)
- `344359e` Add AVRCP debug buttons, fix btmon capture, revert harmful bounce
- `ac47287` Disconnect HFP after connect, upgrade BlueZ to 5.85
- `67945a2` Fix device operations when store is empty (auto-create wrappers)
- `e9a52c1` Disable volume poll loop that triggers harmful renegotiations

## Test plan

- [x] Startup detects connected devices not in store and creates wrappers
- [x] HFP DisconnectProfile succeeds at startup
- [x] Volume poll loop no longer triggers renegotiations
- [ ] Volume buttons work after HFP disconnect (investigating)
- [ ] Disconnect/Forget buttons work with empty store

🤖 Generated with [Claude Code](https://claude.com/claude-code)