### PR TITLE
Fix AVRCP volume: HFP disconnect, debug buttons, resilient device wrappers

### DIFF
--- a/bluetooth_audio_manager/config.yaml
+++ b/bluetooth_audio_manager/config.yaml
@@ -1,5 +1,5 @@
 name: "Bluetooth Audio Manager"
-version: "0.1.75"
+version: "0.1.76"
 slug: bluetooth_audio_manager
 description: "Manage Bluetooth audio device connections (A2DP) with persistent pairing, auto-reconnect, and AppArmor security."
 url: "https://github.com/scyto/ha-bluetooth-audio-manager"

--- a/bluetooth_audio_manager/rootfs/usr/src/bt_audio_manager/web/api.py
+++ b/bluetooth_audio_manager/rootfs/usr/src/bt_audio_manager/web/api.py
@@ -385,6 +385,36 @@ def create_api_routes(manager: "BluetoothAudioManager") -> list[web.RouteDef]:
             logger.error("debug_disconnect_hfp failed for %s: %s", address, e)
             return web.json_response({"error": _friendly_error(e)}, status=500)
 
+    @routes.post("/api/debug/hfp-reconnect-cycle")
+    async def debug_hfp_reconnect_cycle(request: web.Request) -> web.Response:
+        """Debug: disconnect HFP, full reconnect, disconnect HFP again."""
+        address = None
+        try:
+            body = await request.json()
+            address = body.get("address")
+            if not address:
+                return web.json_response({"error": "address is required"}, status=400)
+            result = await manager.debug_hfp_reconnect_cycle(address)
+            return web.json_response(result)
+        except Exception as e:
+            logger.error("debug_hfp_reconnect_cycle failed for %s: %s", address, e)
+            return web.json_response({"error": _friendly_error(e)}, status=500)
+
+    @routes.post("/api/debug/register-null-hfp")
+    async def debug_register_null_hfp(request: web.Request) -> web.Response:
+        """Debug: register null HFP profile handler to block HFP."""
+        address = None
+        try:
+            body = await request.json()
+            address = body.get("address")
+            if not address:
+                return web.json_response({"error": "address is required"}, status=400)
+            result = await manager.debug_register_null_hfp(address)
+            return web.json_response(result)
+        except Exception as e:
+            logger.error("debug_register_null_hfp failed for %s: %s", address, e)
+            return web.json_response({"error": _friendly_error(e)}, status=500)
+
     @routes.get("/api/diagnostics/mpris")
     async def diagnostics_mpris(request: web.Request) -> web.Response:
         """Diagnostic endpoint for MPRIS/AVRCP troubleshooting."""

--- a/bluetooth_audio_manager/rootfs/usr/src/bt_audio_manager/web/static/app.js
+++ b/bluetooth_audio_manager/rootfs/usr/src/bt_audio_manager/web/static/app.js
@@ -332,6 +332,28 @@ async function debugDisconnectHfp(address) {
   }
 }
 
+async function debugHfpReconnectCycle(address) {
+  try {
+    showStatus(`HFP Reconnect Cycle on ${address} (audio will drop)...`);
+    await apiPost("/api/debug/hfp-reconnect-cycle", { address });
+  } catch (e) {
+    showError(`HFP Reconnect Cycle failed: ${e.message}`);
+  } finally {
+    hideStatus();
+  }
+}
+
+async function debugRegisterNullHfp(address) {
+  try {
+    showStatus(`Registering Null HFP Handler + reconnect on ${address} (audio will drop)...`);
+    await apiPost("/api/debug/register-null-hfp", { address });
+  } catch (e) {
+    showError(`Register Null HFP failed: ${e.message}`);
+  } finally {
+    hideStatus();
+  }
+}
+
 function renderDebugActions(devices) {
   const container = $("#debug-actions");
   const placeholder = $("#debug-placeholder");
@@ -359,6 +381,8 @@ function renderDebugActions(devices) {
           <button class="btn btn-small btn-warning" onclick="debugMprisAvrcpCycle('${d.address}')">MPRIS+AVRCP Cycle</button>
           <button class="btn btn-small btn-danger" onclick="debugFullRenegotiate('${d.address}')">Full Renegotiate</button>
           <button class="btn btn-small btn-primary" onclick="debugDisconnectHfp('${d.address}')">Disconnect HFP</button>
+          <button class="btn btn-small btn-danger" onclick="debugHfpReconnectCycle('${d.address}')">HFP + Reconnect</button>
+          <button class="btn btn-small btn-warning" onclick="debugRegisterNullHfp('${d.address}')">Null HFP Handler</button>
         </div>
       </div>
     `)


### PR DESCRIPTION
## Summary
- **HFP disconnect for AVRCP volume**: Bose (and similar) speakers route volume buttons via HFP AT+VGS instead of AVRCP. Disconnecting HFP forces fallback to AVRCP absolute volume, which BlueZ properly propagates.
- **Auto-create BluezDevice wrappers**: Device operations (Disconnect, Forget, debug buttons) no longer silently fail when the store is empty but BlueZ has connected devices. Startup now detects connected devices and creates wrappers on demand.
- **Disable harmful volume poll loop**: The poll loop triggered unnecessary disconnect/reconnect renegotiations after 15s without AVRCP volume signals.
- **New debug buttons**: "HFP + Reconnect" (full reconnect cycle without HFP) and "Null HFP Handler" (register as HFP profile handler via ProfileManager1 to intercept/block HFP connections).
- **BlueZ 5.85 upgrade** to match HAOS host version.

## Test plan
- [ ] Deploy with empty store — device auto-gets a BluezDevice wrapper at startup
- [ ] All UI buttons (Disconnect, Forget, debug) work on unmanaged devices
- [ ] "HFP + Reconnect" button: disconnects, reconnects, removes HFP — volume buttons work
- [ ] "Null HFP Handler" button: registers null profile, reconnects — HFP blocked
- [ ] No spurious renegotiations from disabled volume poll loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)