### PR TITLE
Fix AVRCP volume: adapter discovery, null HFP handler, auto PlaybackStatus

### DIFF
--- a/bluetooth_audio_manager/config.yaml
+++ b/bluetooth_audio_manager/config.yaml
@@ -1,5 +1,5 @@
 name: "Bluetooth Audio Manager"
-version: "0.1.78"
+version: "0.1.79"
 slug: bluetooth_audio_manager
 description: "Manage Bluetooth audio device connections (A2DP) with persistent pairing, auto-reconnect, and AppArmor security."
 url: "https://github.com/scyto/ha-bluetooth-audio-manager"


### PR DESCRIPTION
## Summary
- **Adapter-aware device lookup**: All device operations now discover the actual adapter via ObjectManager instead of hardcoding the configured adapter. Fixes forget/disconnect/connect targeting wrong D-Bus path when device is paired on a different adapter (e.g. hci0 vs hci2).
- **Null HFP profile handler**: Registered at startup to block HFP connections. Speakers like Bose send volume as HFP AT+VGS (invisible to A2DP), blocking HFP forces them to use AVRCP absolute volume which BlueZ correctly propagates.
- **Auto PlaybackStatus signaling**: Detects MediaTransport1.State="active" and auto-sets MPRIS PlaybackStatus="Playing" so speakers enable AVRCP volume buttons immediately without the user pressing Play.
- **Simplified startup**: Replaced disruptive HFP reconnect cycle (full disconnect/reconnect causing page timeouts) with simple `_disconnect_hfp()` — the null handler already prevents new HFP connections.
- **Debug tooling**: AVRCP debug buttons, btmon capture, HFP reconnect/null-handler debug endpoints.
- **BlueZ 5.85 upgrade** and miscellaneous fixes (empty store handling, volume poll disabled).

## Test plan
- [ ] Deploy and verify volume +/- buttons work on Bose speaker immediately after audio starts streaming (no Play press needed)
- [ ] Verify forget button removes device from correct adapter
- [ ] Check startup logs show "Null HFP profile handler registered" and no page timeout errors
- [ ] Confirm no HFP AT+VGS commands in btmon after connecting

🤖 Generated with [Claude Code](https://claude.com/claude-code)