### PR TITLE
Set PlaybackStatus=Playing at startup if transport already active

### DIFF
--- a/bluetooth_audio_manager/config.yaml
+++ b/bluetooth_audio_manager/config.yaml
@@ -1,5 +1,5 @@
 name: "Bluetooth Audio Manager"
-version: "0.1.79"
+version: "0.1.80"
 slug: bluetooth_audio_manager
 description: "Manage Bluetooth audio device connections (A2DP) with persistent pairing, auto-reconnect, and AppArmor security."
 url: "https://github.com/scyto/ha-bluetooth-audio-manager"


### PR DESCRIPTION
## Summary
- When the add-on restarts while a device is already connected and streaming, the MediaTransport1 State is already `active` — we never see the transition signal, so volume buttons don't work until Play is pressed
- Adds step 6c at startup: query ObjectManager for any existing `MediaTransport1` with `State="active"` and proactively set MPRIS `PlaybackStatus="Playing"`

## Test plan
- [ ] Restart add-on while speaker is connected and audio is streaming
- [ ] Verify volume +/- buttons work immediately without pressing Play
- [ ] Check logs show "Active A2DP transport found at startup" message

🤖 Generated with [Claude Code](https://claude.com/claude-code)