### PR TITLE
AVRCP volume fix, adapter selection, WebSocket real-time UI

### DIFF
--- a/bluetooth_audio_manager/config.yaml
+++ b/bluetooth_audio_manager/config.yaml
@@ -1,5 +1,5 @@
 name: "Bluetooth Audio Manager"
-version: "0.1.81"
+version: "0.1.82"
 slug: bluetooth_audio_manager
 description: "Manage Bluetooth audio device connections (A2DP) with persistent pairing, auto-reconnect, and AppArmor security."
 url: "https://github.com/scyto/ha-bluetooth-audio-manager"

--- a/bluetooth_audio_manager/rootfs/usr/src/bt_audio_manager/web/events.py
+++ b/bluetooth_audio_manager/rootfs/usr/src/bt_audio_manager/web/events.py
@@ -1,4 +1,4 @@
-"""Server-Sent Events (SSE) event bus for real-time UI updates."""
+"""Event bus for real-time UI updates via WebSocket."""
 
 import asyncio
 import logging
@@ -7,33 +7,33 @@ logger = logging.getLogger(__name__)
 
 
 class EventBus:
-    """Simple pub/sub using asyncio.Queue per connected SSE client."""
+    """Simple pub/sub using asyncio.Queue per connected WebSocket client."""
 
     def __init__(self):
         self._clients: set[asyncio.Queue] = set()
 
     def subscribe(self) -> asyncio.Queue:
-        """Add a new SSE client. Returns a queue to read events from."""
+        """Add a new client. Returns a queue to read events from."""
         q: asyncio.Queue = asyncio.Queue(maxsize=64)
         self._clients.add(q)
-        logger.info("SSE client subscribed (%d total)", len(self._clients))
+        logger.info("EventBus client subscribed (%d total)", len(self._clients))
         return q
 
     def unsubscribe(self, q: asyncio.Queue) -> None:
-        """Remove an SSE client."""
+        """Remove a client."""
         self._clients.discard(q)
-        logger.info("SSE client unsubscribed (%d remaining)", len(self._clients))
+        logger.info("EventBus client unsubscribed (%d remaining)", len(self._clients))
 
     def emit(self, event: str, data: dict) -> None:
         """Push an event to all connected clients."""
         if not self._clients:
             return
-        logger.info("EventBus emit: %s → %d client(s)", event, len(self._clients))
+        logger.debug("EventBus emit: %s → %d client(s)", event, len(self._clients))
         for q in self._clients:
             try:
                 q.put_nowait({"event": event, "data": data})
             except asyncio.QueueFull:
-                logger.warning("Dropping SSE event '%s' for slow client (queue full)", event)
+                logger.warning("Dropping event '%s' for slow client (queue full)", event)
 
     @property
     def client_count(self) -> int:


### PR DESCRIPTION
## Summary

- **Fix AVRCP absolute volume**: Block HFP profile (null handler + disconnect cycle) so speakers use AVRCP instead of sending AT+VGS commands that BlueZ can't map to A2DP transport volume
- **Adapter selection**: Auto-detect and select Bluetooth adapters, discover which adapter a device is actually on via ObjectManager, add UI for adapter switching
- **WebSocket real-time updates**: Replace broken SSE (HA ingress compression bug supervisor#6470) with WebSocket — bypasses both the compression bug and service worker. 30s ping/pong keepalive, exponential backoff reconnection (1s→30s)
- **Startup improvements**: Auto-detect active A2DP transports and signal PlaybackStatus=Playing, register null HFP handler at boot, enumerate connected devices not in store
- **BlueZ 5.85**: Pin to Alpine edge packages to match HAOS host version
- **Cleanup**: Remove btmon capture script, dead volume poll loop, debug UI buttons, host_network permission

## Test plan

- [ ] Deploy and verify WebSocket connects (browser console: `[WS] Connected`)
- [ ] Press speaker buttons → MPRIS/AVRCP events appear in UI in real-time
- [ ] Verify volume buttons work via AVRCP (not HFP)
- [ ] Test adapter selection UI if multiple adapters present
- [ ] Verify auto-reconnect still works after add-on restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)