### PR TITLE
WebSocket real-time updates, AVRCP/HFP fixes, adapter discovery

### DIFF
--- a/bluetooth_audio_manager/config.yaml
+++ b/bluetooth_audio_manager/config.yaml
@@ -1,5 +1,5 @@
 name: "Bluetooth Audio Manager"
-version: "0.1.82"
+version: "0.1.83"
 slug: bluetooth_audio_manager
 description: "Manage Bluetooth audio device connections (A2DP) with persistent pairing, auto-reconnect, and AppArmor security."
 url: "https://github.com/scyto/ha-bluetooth-audio-manager"

--- a/bluetooth_audio_manager/rootfs/usr/src/bt_audio_manager/web/api.py
+++ b/bluetooth_audio_manager/rootfs/usr/src/bt_audio_manager/web/api.py
@@ -194,8 +194,11 @@ def create_api_routes(manager: "BluetoothAudioManager") -> list[web.RouteDef]:
             devices = await manager.scan_devices(duration)
             return web.json_response({"devices": devices})
         except Exception as e:
+            if "In Progress" in str(e):
+                # Scan already running — not an error
+                return web.json_response({"scanning": True})
             logger.error("Scan failed: %s", e)
-            return web.json_response({"error": str(e)}, status=500)
+            return web.json_response({"error": _friendly_error(e)}, status=500)
 
     @routes.post("/api/pair")
     async def pair(request: web.Request) -> web.Response:

--- a/bluetooth_audio_manager/rootfs/usr/src/bt_audio_manager/web/static/style.css
+++ b/bluetooth_audio_manager/rootfs/usr/src/bt_audio_manager/web/static/style.css
@@ -119,6 +119,11 @@ header h1 {
   font-size: 0.875rem;
 }
 
+.status-bar.error {
+  border-color: var(--danger);
+  color: var(--danger);
+}
+
 .hidden { display: none !important; }
 
 .spinner {


### PR DESCRIPTION
## Summary
- **WebSocket replaces polling**: Real-time UI updates via `WebSocketResponse(heartbeat=30)` with dual-loop pattern. SSE is broken through HA ingress (supervisor#6470). All status, device changes, sink updates, MPRIS commands, and AVRCP events stream through WS.
- **Server-driven status bar**: UI progress indicators (scanning, connecting, pairing...) driven by WebSocket `status` events from the server, not client-side handlers. Errors show in status bar with auto-dismiss.
- **AVRCP volume fix**: Null HFP profile handler blocks HFP so speakers fall back to AVRCP absolute volume. HFP reconnect cycle for stubborn speakers (Bose).
- **Adapter discovery**: `_find_device_adapter()` via ObjectManager so devices paired on a different adapter still work.
- **MPRIS player registration**: PlaybackStatus=Playing signaled on A2DP transport active to enable speaker volume buttons.
- **Dead code cleanup**: Removed volume poll renegotiation loop, debug UI buttons, btmon capture script.

## Test plan
- [ ] WebSocket connects through HA ingress (`[WS] Connected` in console)
- [ ] Status bar shows spinner during scan/connect/pair operations
- [ ] Scan "already in progress" returns 200 (not 500 error)
- [ ] Device list not destroyed on errors (errors show in status bar)
- [ ] AVRCP volume buttons work on connected speaker
- [ ] Adapter selector works with multiple BT adapters

🤖 Generated with [Claude Code](https://claude.com/claude-code)