### PR TITLE
WebSocket real-time updates, AVRCP fixes, dead code cleanup

### DIFF
--- a/bluetooth_audio_manager/config.yaml
+++ b/bluetooth_audio_manager/config.yaml
@@ -1,5 +1,5 @@
 name: "Bluetooth Audio Manager"
-version: "0.1.83"
+version: "0.1.84"
 slug: bluetooth_audio_manager
 description: "Manage Bluetooth audio device connections (A2DP) with persistent pairing, auto-reconnect, and AppArmor security."
 url: "https://github.com/scyto/ha-bluetooth-audio-manager"


### PR DESCRIPTION
## Summary
- **WebSocket replaces polling**: Server-driven real-time UI via `aiohttp WebSocketResponse(heartbeat=30)` with exponential backoff reconnection on the client. Bypasses HA ingress compression bug (supervisor#6470) and service worker.
- **Server-driven status bar**: All operation status (scan, pair, connect, disconnect, forget) pushed via WebSocket `status` events with spinner — no more client-side status management.
- **AVRCP/HFP volume fix**: Null HFP profile handler blocks HFP connections, forcing speakers (e.g. Bose) to use AVRCP absolute volume. Auto-discovers actual device adapter via ObjectManager.
- **A2DP transport reliability**: Auto-signals `PlaybackStatus=Playing` on active transport, `ConnectProfile(A2DP)` fallback, and disconnect/reconnect cycle for BLE-only stuck devices.
- **Dead code cleanup**: Removed volume poll loop (caused harmful renegotiations), debug UI buttons, btmon capture script, and stale SSE code.

## Test plan
- [ ] WebSocket connects through HA ingress (console shows `[WS] Connected`)
- [ ] Device scan shows spinner in status bar, clears on completion
- [ ] Pair/connect/disconnect/forget all show status and clear properly
- [ ] AVRCP volume buttons work on Bose/similar speakers
- [ ] MPRIS commands and AVRCP events stream in real-time in the UI
- [ ] WebSocket auto-reconnects after disconnect (exponential backoff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)