### PR TITLE
Fix stuck status bar after connect, pair, and forget

### DIFF
--- a/bluetooth_audio_manager/config.yaml
+++ b/bluetooth_audio_manager/config.yaml
@@ -1,5 +1,5 @@
 name: "Bluetooth Audio Manager"
-version: "0.1.83"
+version: "0.1.84"
 slug: bluetooth_audio_manager
 description: "Manage Bluetooth audio device connections (A2DP) with persistent pairing, auto-reconnect, and AppArmor security."
 url: "https://github.com/scyto/ha-bluetooth-audio-manager"


### PR DESCRIPTION
## Summary
- Clear status bar in `connect_device` finally block, `pair_device` error path, and `forget_device` completion
- Status bar was stuck showing "Connecting..." / "Pairing..." / "Forgetting..." after operations completed

## Test plan
- [ ] Connect to a device — status bar clears after connection completes
- [ ] Pair a new device — status bar clears on success or failure
- [ ] Forget a device — status bar clears after removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)