### PR TITLE
Fix double HFP disconnect race during pair

### DIFF
--- a/bluetooth_audio_manager/config.yaml
+++ b/bluetooth_audio_manager/config.yaml
@@ -1,5 +1,5 @@
 name: "Bluetooth Audio Manager"
-version: "0.1.89"
+version: "0.1.90"
 slug: bluetooth_audio_manager
 description: "Manage Bluetooth audio device connections (A2DP) with persistent pairing, auto-reconnect, and AppArmor security."
 url: "https://github.com/scyto/ha-bluetooth-audio-manager"


### PR DESCRIPTION
## Summary
- Fix race condition where HFP disconnect fires twice during pair, causing the Bose speaker to drop the connection with `br-connection-key-missing`
- Add address to `_connecting` set before `device.pair()` so the Connected signal handler's guard suppresses the duplicate HFP disconnect

## Test plan
- [ ] Forget a paired device, re-scan, and pair again — should connect with a single HFP disconnect and A2DP sink appears
- [ ] Verify normal connect/disconnect flow still works for already-paired devices
- [ ] Verify auto-reconnect still works after reboot

🤖 Generated with [Claude Code](https://claude.com/claude-code)