### PR TITLE
Fix infinite A2DP retry loop causing connect/disconnect flicker

### DIFF
--- a/bluetooth_audio_manager/config.yaml
+++ b/bluetooth_audio_manager/config.yaml
@@ -1,5 +1,5 @@
 name: "Bluetooth Audio Manager"
-version: "0.1.90"
+version: "0.1.91"
 slug: bluetooth_audio_manager
 description: "Manage Bluetooth audio device connections (A2DP) with persistent pairing, auto-reconnect, and AppArmor security."
 url: "https://github.com/scyto/ha-bluetooth-audio-manager"


### PR DESCRIPTION
## Summary
- **Fix re-entrant A2DP activation loop**: `_ensure_a2dp_transport()` disconnect/reconnect cycle was firing a new `Connected` D-Bus signal, re-triggering `_on_device_connected_async()` which called `_ensure_a2dp_transport()` again in an infinite loop (~6s per cycle)
- **Add `_connecting` guard**: The disconnect/reconnect cycle now marks the address in `self._connecting` so the signal handler skips re-entry (matching the pattern used by `pair_device` and `_hfp_reconnect_cycle`)
- **Add max attempt counter** (`MAX_A2DP_ATTEMPTS = 3`): After 3 consecutive failed A2DP activations, logs a warning and gives up. Counter resets on success, fresh pair, or forget

## Test plan
- [ ] Pair a Bluetooth speaker that previously caused the flicker loop — verify it no longer cycles indefinitely
- [ ] Confirm successful A2DP connections still work normally (counter resets on success)
- [ ] Forget and re-pair a device — verify the retry counter resets and allows fresh attempts

🤖 Generated with [Claude Code](https://claude.com/claude-code)