### PR TITLE
Per-device keep-alive settings with kebab menu

### DIFF
--- a/bluetooth_audio_manager/DOCS.md
+++ b/bluetooth_audio_manager/DOCS.md
@@ -38,13 +38,15 @@ Bluetooth integration (used for BLE sensors, beacons, etc.):
 | `auto_reconnect` | `true` | Automatically reconnect disconnected devices |
 | `reconnect_interval_seconds` | `30` | Initial reconnection delay |
 | `reconnect_max_backoff_seconds` | `300` | Maximum reconnection delay |
-| `keep_alive_enabled` | `false` | Stream inaudible audio to prevent speaker sleep |
-| `keep_alive_method` | `infrasound` | Keep-alive type: `silence` or `infrasound` |
 | `scan_duration_seconds` | `15` | How long to scan for devices |
 
-### Keep-alive methods
+### Per-device keep-alive
 
-Many Bluetooth speakers enter standby after a period of silence:
+Many Bluetooth speakers enter standby after a period of silence. Keep-alive
+streams inaudible audio to prevent this. It is configured per-device in the
+web UI: open the device's menu (three-dot icon) and select **Settings**.
+
+Two methods are available:
 
 - **infrasound** (recommended): Streams a 2 Hz sine wave at very low amplitude.
   Below human hearing threshold. Prevents speakers that detect digital silence
@@ -78,8 +80,9 @@ Some devices exit pairing mode after 30-60 seconds.
 **Connected but no audio**: Check Settings > System > Audio to verify the
 Bluetooth sink is listed. Try setting it as the default output.
 
-**Speaker keeps disconnecting**: Enable the keep-alive option in the add-on
-configuration. Try the `infrasound` method if `silence` doesn't work.
+**Speaker keeps disconnecting**: Enable keep-alive for the device in the web
+UI (device menu > Settings). Try the `infrasound` method if `silence` doesn't
+work.
 
 **Existing BLE integrations stopped working**: This should not happen by
 design. Check the add-on logs for errors and file an issue on GitHub.

--- a/bluetooth_audio_manager/config.yaml
+++ b/bluetooth_audio_manager/config.yaml
@@ -1,5 +1,5 @@
 name: "Bluetooth Audio Manager"
-version: "0.1.91"
+version: "0.1.92"
 slug: bluetooth_audio_manager
 description: "Manage Bluetooth audio device connections (A2DP) with persistent pairing, auto-reconnect, and AppArmor security."
 url: "https://github.com/scyto/ha-bluetooth-audio-manager"
@@ -37,8 +37,6 @@ options:
   auto_reconnect: true
   reconnect_interval_seconds: 30
   reconnect_max_backoff_seconds: 300
-  keep_alive_enabled: false
-  keep_alive_method: "infrasound"
   scan_duration_seconds: 30
   bt_adapter: "auto"
 
@@ -47,8 +45,6 @@ schema:
   auto_reconnect: bool
   reconnect_interval_seconds: "int(5,600)"
   reconnect_max_backoff_seconds: "int(60,3600)"
-  keep_alive_enabled: bool
-  keep_alive_method: "list(silence|infrasound)"
   scan_duration_seconds: "int(5,60)"
   bt_adapter: "str"
 

--- a/bluetooth_audio_manager/rootfs/usr/src/bt_audio_manager/config.py
+++ b/bluetooth_audio_manager/rootfs/usr/src/bt_audio_manager/config.py
@@ -22,8 +22,6 @@ class AppConfig:
     auto_reconnect: bool = True
     reconnect_interval_seconds: int = 30
     reconnect_max_backoff_seconds: int = 300
-    keep_alive_enabled: bool = False
-    keep_alive_method: str = "infrasound"
     scan_duration_seconds: int = 15
     bt_adapter: str = "auto"
 
@@ -56,8 +54,6 @@ class AppConfig:
                 auto_reconnect=data.get("auto_reconnect", True),
                 reconnect_interval_seconds=data.get("reconnect_interval_seconds", 30),
                 reconnect_max_backoff_seconds=data.get("reconnect_max_backoff_seconds", 300),
-                keep_alive_enabled=data.get("keep_alive_enabled", False),
-                keep_alive_method=data.get("keep_alive_method", "infrasound"),
                 scan_duration_seconds=data.get("scan_duration_seconds", 15),
                 bt_adapter=data.get("bt_adapter", "auto"),
             )

--- a/bluetooth_audio_manager/rootfs/usr/src/bt_audio_manager/web/static/index.html
+++ b/bluetooth_audio_manager/rootfs/usr/src/bt_audio_manager/web/static/index.html
@@ -200,6 +200,53 @@
     </div>
   </div>
 
+  <!-- ========== DEVICE SETTINGS MODAL ========== -->
+  <div class="modal fade" id="deviceSettingsModal" tabindex="-1">
+    <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title"><i class="fas fa-cog me-2"></i>Device Settings</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+        </div>
+        <div class="modal-body">
+          <h6 id="device-settings-name" class="fw-semibold mb-1"></h6>
+          <p id="device-settings-address" class="font-monospace small text-muted mb-3"></p>
+
+          <!-- Keep-Alive Toggle -->
+          <div class="mb-3">
+            <div class="form-check form-switch">
+              <input class="form-check-input" type="checkbox" id="setting-keep-alive-enabled">
+              <label class="form-check-label" for="setting-keep-alive-enabled">
+                <strong>Keep-Alive</strong>
+              </label>
+            </div>
+            <div class="form-text">
+              Stream inaudible audio to prevent the speaker from auto-shutting down during silence.
+            </div>
+          </div>
+
+          <!-- Keep-Alive Method -->
+          <div class="mb-3" id="keep-alive-method-group">
+            <label for="setting-keep-alive-method" class="form-label">Keep-Alive Method</label>
+            <select class="form-select" id="setting-keep-alive-method">
+              <option value="infrasound">Infrasound (2 Hz tone &mdash; recommended)</option>
+              <option value="silence">Silence (PCM zeros)</option>
+            </select>
+            <div class="form-text">
+              Infrasound is recommended for speakers that detect digital silence.
+            </div>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+          <button type="button" class="btn btn-primary" onclick="saveDeviceSettings()">
+            <i class="fas fa-save me-1"></i>Save
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <!-- Footer -->
   <footer class="app-footer text-center py-2 text-muted">
     <span id="version-label"></span>

--- a/bluetooth_audio_manager/rootfs/usr/src/bt_audio_manager/web/static/style.css
+++ b/bluetooth_audio_manager/rootfs/usr/src/bt_audio_manager/web/static/style.css
@@ -299,7 +299,49 @@ h1, h2, h3, h4, h5, h6 {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  max-width: calc(100% - 90px);
+  max-width: calc(100% - 130px);
+}
+
+/* Kebab dropdown on device cards */
+.device-card .dropdown .btn-link {
+  opacity: 0.4;
+  transition: opacity var(--transition-fast);
+  font-size: 0.875rem;
+  line-height: 1;
+}
+
+.device-card:hover .dropdown .btn-link {
+  opacity: 0.7;
+}
+
+.device-card .dropdown .btn-link:hover {
+  opacity: 1;
+}
+
+.device-card .dropdown-menu {
+  border: 1px solid var(--bs-border-color);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-lg);
+  padding: 0.5rem;
+  min-width: 160px;
+}
+
+.device-card .dropdown-item {
+  border-radius: var(--radius-sm);
+  padding: 0.5rem 0.75rem;
+  font-size: 0.875rem;
+  transition: background var(--transition-fast);
+}
+
+/* Keep-alive heartbeat indicator */
+.keep-alive-indicator {
+  font-size: 0.75rem;
+  animation: heartbeat 1.5s ease-in-out infinite;
+}
+
+@keyframes heartbeat {
+  0%, 100% { opacity: 0.6; transform: scale(1); }
+  50% { opacity: 1; transform: scale(1.15); }
 }
 
 .device-card .card-body {

--- a/bluetooth_audio_manager/translations/en.yaml
+++ b/bluetooth_audio_manager/translations/en.yaml
@@ -11,14 +11,6 @@ configuration:
   reconnect_max_backoff_seconds:
     name: Max Reconnect Backoff
     description: Maximum delay in seconds between reconnection attempts (exponential backoff cap).
-  keep_alive_enabled:
-    name: Keep-Alive
-    description: Stream inaudible audio to prevent Bluetooth speakers from auto-shutting down.
-  keep_alive_method:
-    name: Keep-Alive Method
-    description: >-
-      Type of inaudible audio to stream. "infrasound" sends a 2Hz tone (recommended
-      for speakers that detect digital silence). "silence" sends PCM zeros.
   scan_duration_seconds:
     name: Scan Duration
     description: How long to scan for discoverable Bluetooth audio devices (in seconds).


### PR DESCRIPTION
## Summary
- Move keep-alive from global HAOS add-on config to **per-device settings** managed through the web UI
- Add 3-dot kebab menu on each device tile with **Settings** (opens modal) and **Forget Device**
- One-time migration from global config for upgrading users (gated by `/data/.keepalive_migrated` marker)

## Changes (10 files, 1 commit)
- **store.py**: `update_device_settings()` + `get_device_settings()` with defaults for missing keys
- **config.py / config.yaml / translations/en.yaml**: Remove global `keep_alive_enabled` and `keep_alive_method`
- **manager.py**: Replace single `KeepAliveService` with per-device `dict[str, KeepAliveService]`, migration logic, lifecycle management (start on connect, stop on disconnect, immediate reaction to settings changes)
- **api.py**: `PUT /api/devices/{address}/settings` endpoint with validation
- **index.html**: Device Settings modal with keep-alive toggle + method selector
- **app.js**: Kebab dropdown, modal open/save logic, `keepalive_changed` WS handler, heartbeat indicator
- **style.css**: Kebab button styling, dropdown menu, animated heartbeat indicator
- **DOCS.md**: Updated to reference per-device UI settings

## Test plan
- [ ] Pair a device, open kebab menu, go to Settings, enable keep-alive with infrasound, save
- [ ] Verify `pacat` process starts streaming to the device's PA sink
- [ ] Disconnect device — verify keep-alive stops
- [ ] Reconnect — verify keep-alive auto-starts
- [ ] Change method to silence while connected — verify immediate restart with new method
- [ ] Disable keep-alive while connected — verify immediate stop
- [ ] Test with multiple connected devices — each should have independent keep-alive
- [ ] Forget a device — verify keep-alive stops and settings are removed
- [ ] Upgrade from previous version with global keep-alive enabled — verify migration applies to all stored devices

🤖 Generated with [Claude Code](https://claude.com/claude-code)