### PR TITLE
Filter stale BlueZ cache from discovery, add pairing troubleshooting

### DIFF
--- a/bluetooth_audio_manager/DOCS.md
+++ b/bluetooth_audio_manager/DOCS.md
@@ -84,5 +84,16 @@ Bluetooth sink is listed. Try setting it as the default output.
 UI (device menu > Settings). Try the `infrasound` method if `silence` doesn't
 work.
 
+**`br-connection-key-missing` error when connecting**: The pairing keys stored
+by BlueZ are out of sync with the speaker. Click **Forget** in the add-on UI,
+then clear the pairing on the speaker itself (usually hold the Bluetooth button
+for ~10 seconds until the speaker announces "ready to pair" or the LED enters
+pairing mode). Then scan and pair again from the add-on.
+
+**`Authentication Rejected` when pairing**: The speaker still has old pairing
+keys for your system's Bluetooth address and is refusing the new pairing
+attempt. Clear the speaker's paired-device list (hold the Bluetooth button for
+~10 seconds) so both sides start fresh, then re-pair from the add-on.
+
 **Existing BLE integrations stopped working**: This should not happen by
 design. Check the add-on logs for errors and file an issue on GitHub.

--- a/bluetooth_audio_manager/config.yaml
+++ b/bluetooth_audio_manager/config.yaml
@@ -1,5 +1,5 @@
 name: "Bluetooth Audio Manager"
-version: "0.1.92"
+version: "0.1.93"
 slug: bluetooth_audio_manager
 description: "Manage Bluetooth audio device connections (A2DP) with persistent pairing, auto-reconnect, and AppArmor security."
 url: "https://github.com/scyto/ha-bluetooth-audio-manager"

--- a/bluetooth_audio_manager/rootfs/usr/src/bt_audio_manager/bluez/adapter.py
+++ b/bluetooth_audio_manager/rootfs/usr/src/bt_audio_manager/bluez/adapter.py
@@ -129,6 +129,14 @@ class BluezAdapter:
             connected_variant = props.get("Connected")
             rssi_variant = props.get("RSSI")
 
+            paired = paired_variant.value if paired_variant else False
+            connected = connected_variant.value if connected_variant else False
+            rssi = rssi_variant.value if rssi_variant else None
+
+            # Skip stale BlueZ cache entries: unpaired, disconnected, no recent RSSI
+            if not paired and not connected and rssi is None:
+                continue
+
             # Detect active bearers (BR/EDR vs LE)
             bearers = []
             for iface_name in interfaces:
@@ -163,9 +171,9 @@ class BluezAdapter:
                     "adapter": adapter_name,
                     "address": address_variant.value if address_variant else "unknown",
                     "name": name_variant.value if name_variant else "Unknown Device",
-                    "paired": paired_variant.value if paired_variant else False,
-                    "connected": connected_variant.value if connected_variant else False,
-                    "rssi": rssi_variant.value if rssi_variant else None,
+                    "paired": paired,
+                    "connected": connected,
+                    "rssi": rssi,
                     "uuids": list(uuids),
                     "bearers": bearers,
                     "has_transport": has_transport,


### PR DESCRIPTION
## Summary
- **Filter stale discovered devices**: Skip unpaired/disconnected devices with no RSSI in `get_audio_devices()` so BlueZ cache entries don't appear as "DISCOVERED" when the device is powered off
- **Add troubleshooting docs**: Document `br-connection-key-missing` and `Authentication Rejected` errors — both caused by one-sided pairing key mismatch, fixed by clearing pairing on the speaker side

## Test plan
- [ ] Reboot add-on with a previously-discovered speaker powered off — it should NOT appear in the device list
- [ ] Start discovery with the speaker on — it should appear with RSSI and "DISCOVERED" badge
- [ ] Paired offline devices still appear (sourced from persistent store, not BlueZ cache)

🤖 Generated with [Claude Code](https://claude.com/claude-code)