### PR TITLE
Clean up stale BlueZ device cache at startup

### DIFF
--- a/bluetooth_audio_manager/config.yaml
+++ b/bluetooth_audio_manager/config.yaml
@@ -1,5 +1,5 @@
 name: "Bluetooth Audio Manager"
-version: "0.1.93"
+version: "0.1.94"
 slug: bluetooth_audio_manager
 description: "Manage Bluetooth audio device connections (A2DP) with persistent pairing, auto-reconnect, and AppArmor security."
 url: "https://github.com/scyto/ha-bluetooth-audio-manager"

--- a/bluetooth_audio_manager/rootfs/usr/src/bt_audio_manager/bluez/adapter.py
+++ b/bluetooth_audio_manager/rootfs/usr/src/bt_audio_manager/bluez/adapter.py
@@ -133,10 +133,6 @@ class BluezAdapter:
             connected = connected_variant.value if connected_variant else False
             rssi = rssi_variant.value if rssi_variant else None
 
-            # Skip stale BlueZ cache entries: unpaired, disconnected, no recent RSSI
-            if not paired and not connected and rssi is None:
-                continue
-
             # Detect active bearers (BR/EDR vs LE)
             bearers = []
             for iface_name in interfaces:


### PR DESCRIPTION
## Summary
- **Remove stale BlueZ device objects on boot**: At startup (step 6a), removes unpaired/disconnected audio device objects from BlueZ that aren't in the persistent store. Prevents ghost "DISCOVERED" entries from devices that are powered off
- **Reverts RSSI-based filtering**: The previous approach of filtering by RSSI in `get_audio_devices()` was too aggressive — BlueZ can clear RSSI after discovery stops, which hid freshly-discovered devices

## Test plan
- [ ] Reboot add-on with a previously-discovered speaker powered off — ghost entry should NOT appear
- [ ] Start discovery with speaker on — device should appear normally and be pairable
- [ ] Paired offline devices still appear in the UI (sourced from persistent store)

🤖 Generated with [Claude Code](https://claude.com/claude-code)