### PR TITLE
Move add-on settings from HAOS config page to in-app UI

### DIFF
--- a/bluetooth_audio_manager/config.yaml
+++ b/bluetooth_audio_manager/config.yaml
@@ -1,5 +1,5 @@
 name: "Bluetooth Audio Manager"
-version: "0.1.95"
+version: "0.1.96"
 slug: bluetooth_audio_manager
 description: "Manage Bluetooth audio device connections (A2DP) with persistent pairing, auto-reconnect, and AppArmor security."
 url: "https://github.com/scyto/ha-bluetooth-audio-manager"
@@ -31,22 +31,12 @@ map:
   - type: data
     read_only: false
 
-# User options
+# User options (runtime settings are managed in the add-on UI)
 options:
   log_level: "info"
-  auto_reconnect: true
-  reconnect_interval_seconds: 30
-  reconnect_max_backoff_seconds: 300
-  scan_duration_seconds: 30
-  bt_adapter: "auto"
 
 schema:
   log_level: "list(debug|info|warning|error)"
-  auto_reconnect: bool
-  reconnect_interval_seconds: "int(5,600)"
-  reconnect_max_backoff_seconds: "int(60,3600)"
-  scan_duration_seconds: "int(5,60)"
-  bt_adapter: "str"
 
 apparmor: true
 watchdog: "http://[HOST]:[PORT:8099]/api/health"

--- a/bluetooth_audio_manager/rootfs/usr/src/bt_audio_manager/config.py
+++ b/bluetooth_audio_manager/rootfs/usr/src/bt_audio_manager/config.py
@@ -2,28 +2,45 @@
 
 Reads user options from /data/options.json which is injected by
 the HA Supervisor based on the schema defined in config.yaml.
+
+Runtime settings (auto_reconnect, reconnect intervals, scan duration,
+bt_adapter) are stored in /data/settings.json and managed via the
+add-on's web UI.
 """
 
 import json
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
 OPTIONS_PATH = "/data/options.json"
+SETTINGS_PATH = "/data/settings.json"
+
+# Keys that live in settings.json (managed via add-on UI)
+_SETTINGS_KEYS = {
+    "bt_adapter",
+    "auto_reconnect",
+    "reconnect_interval_seconds",
+    "reconnect_max_backoff_seconds",
+    "scan_duration_seconds",
+}
 
 
 @dataclass
 class AppConfig:
-    """Application configuration loaded from HA add-on options."""
+    """Application configuration loaded from HA add-on options + settings."""
 
+    # From options.json (HAOS config page — requires restart)
     log_level: str = "info"
+
+    # From settings.json (add-on UI)
+    bt_adapter: str = "auto"
     auto_reconnect: bool = True
     reconnect_interval_seconds: int = 30
     reconnect_max_backoff_seconds: int = 300
-    scan_duration_seconds: int = 15
-    bt_adapter: str = "auto"
+    scan_duration_seconds: int = 30
 
     @property
     def adapter_path(self) -> str:
@@ -39,24 +56,72 @@ class AppConfig:
             return name
         return f"/org/bluez/{name}"
 
+    @property
+    def runtime_settings(self) -> dict:
+        """Return current runtime settings as a dict."""
+        return {
+            "auto_reconnect": self.auto_reconnect,
+            "reconnect_interval_seconds": self.reconnect_interval_seconds,
+            "reconnect_max_backoff_seconds": self.reconnect_max_backoff_seconds,
+            "scan_duration_seconds": self.scan_duration_seconds,
+        }
+
+    def save_settings(self) -> None:
+        """Write all settings (including bt_adapter) to /data/settings.json."""
+        path = Path(SETTINGS_PATH)
+        data = {
+            "bt_adapter": self.bt_adapter,
+            **self.runtime_settings,
+        }
+        path.write_text(json.dumps(data, indent=2))
+        logger.info("Settings saved to %s", SETTINGS_PATH)
+
     @classmethod
     def load(cls) -> "AppConfig":
-        """Load configuration from the HA options file."""
-        path = Path(OPTIONS_PATH)
-        if not path.exists():
-            logger.warning("Options file not found at %s, using defaults", OPTIONS_PATH)
-            return cls()
+        """Load configuration from HA options + settings files."""
+        config = cls()
 
-        try:
-            data = json.loads(path.read_text())
-            return cls(
-                log_level=data.get("log_level", "info"),
-                auto_reconnect=data.get("auto_reconnect", True),
-                reconnect_interval_seconds=data.get("reconnect_interval_seconds", 30),
-                reconnect_max_backoff_seconds=data.get("reconnect_max_backoff_seconds", 300),
-                scan_duration_seconds=data.get("scan_duration_seconds", 15),
-                bt_adapter=data.get("bt_adapter", "auto"),
-            )
-        except (json.JSONDecodeError, KeyError) as e:
-            logger.error("Failed to parse options: %s, using defaults", e)
-            return cls()
+        # 1. Load log_level from options.json (only setting left on HAOS page)
+        opts_path = Path(OPTIONS_PATH)
+        if opts_path.exists():
+            try:
+                data = json.loads(opts_path.read_text())
+                config.log_level = data.get("log_level", "info")
+            except (json.JSONDecodeError, KeyError) as e:
+                logger.error("Failed to parse options: %s, using defaults", e)
+
+        # 2. Load settings from settings.json
+        settings_path = Path(SETTINGS_PATH)
+        if settings_path.exists():
+            try:
+                settings = json.loads(settings_path.read_text())
+                config.bt_adapter = settings.get("bt_adapter", "auto")
+                config.auto_reconnect = settings.get("auto_reconnect", True)
+                config.reconnect_interval_seconds = settings.get("reconnect_interval_seconds", 30)
+                config.reconnect_max_backoff_seconds = settings.get("reconnect_max_backoff_seconds", 300)
+                config.scan_duration_seconds = settings.get("scan_duration_seconds", 30)
+                logger.info("Loaded settings from %s", SETTINGS_PATH)
+                return config
+            except (json.JSONDecodeError, KeyError) as e:
+                logger.error("Failed to parse settings: %s, trying migration", e)
+
+        # 3. Migration: settings.json doesn't exist — check options.json
+        #    for legacy keys (user upgrading from older version)
+        if opts_path.exists():
+            try:
+                data = json.loads(opts_path.read_text())
+                migrated = False
+                for key in _SETTINGS_KEYS:
+                    if key in data:
+                        setattr(config, key, data[key])
+                        migrated = True
+                if migrated:
+                    config.save_settings()
+                    logger.info("Migrated settings from options.json → settings.json")
+                    return config
+            except (json.JSONDecodeError, KeyError):
+                pass
+
+        # 4. No settings found — save defaults so the file exists
+        config.save_settings()
+        return config

--- a/bluetooth_audio_manager/rootfs/usr/src/bt_audio_manager/web/api.py
+++ b/bluetooth_audio_manager/rootfs/usr/src/bt_audio_manager/web/api.py
@@ -90,12 +90,10 @@ def create_api_routes(
 
     @routes.post("/api/set-adapter")
     async def set_adapter(request: web.Request) -> web.Response:
-        """Set the Bluetooth adapter for this add-on via the HA Supervisor API.
+        """Set the Bluetooth adapter. Persists to settings.json.
 
-        Accepts {"adapter": "hci1"} and updates the add-on options.
-        Requires a restart to take effect.
+        Accepts {"adapter": "hci1"}. Requires a restart to take effect.
         """
-        import aiohttp
         try:
             body = await request.json()
             adapter_name = body.get("adapter")
@@ -104,43 +102,8 @@ def create_api_routes(
                     {"error": "adapter is required"}, status=400
                 )
 
-            supervisor_token = os.environ.get("SUPERVISOR_TOKEN")
-            if not supervisor_token:
-                return web.json_response(
-                    {"error": "Supervisor API not available (not running in HAOS?)"}, status=500
-                )
-
-            # Read current options from Supervisor
-            async with aiohttp.ClientSession() as session:
-                headers = {"Authorization": f"Bearer {supervisor_token}"}
-
-                # Get current options
-                async with session.get(
-                    "http://supervisor/addons/self/options",
-                    headers=headers,
-                ) as resp:
-                    if resp.status != 200:
-                        text = await resp.text()
-                        return web.json_response(
-                            {"error": f"Failed to read current options: {text}"}, status=500
-                        )
-                    result = await resp.json()
-                    current_options = result.get("data", {}).get("options", {})
-
-                # Update bt_adapter
-                current_options["bt_adapter"] = adapter_name
-
-                # Write back via Supervisor
-                async with session.post(
-                    "http://supervisor/addons/self/options",
-                    headers=headers,
-                    json={"options": current_options},
-                ) as resp:
-                    if resp.status != 200:
-                        text = await resp.text()
-                        return web.json_response(
-                            {"error": f"Failed to save options: {text}"}, status=500
-                        )
+            manager.config.bt_adapter = adapter_name
+            manager.config.save_settings()
 
             logger.info("Adapter selection changed to %s (restart required)", adapter_name)
             return web.json_response({
@@ -304,6 +267,56 @@ def create_api_routes(
         except Exception as e:
             logger.error("Failed to update settings for %s: %s", address, e)
             return web.json_response({"error": str(e)}, status=500)
+
+    @routes.get("/api/settings")
+    async def get_settings(request: web.Request) -> web.Response:
+        """Return current runtime settings (auto_reconnect, intervals, etc.)."""
+        return web.json_response(manager.config.runtime_settings)
+
+    @routes.put("/api/settings")
+    async def update_settings(request: web.Request) -> web.Response:
+        """Update runtime settings (hot-reload, no restart needed)."""
+        try:
+            body = await request.json()
+        except Exception:
+            return web.json_response({"error": "Invalid JSON"}, status=400)
+
+        # Validate and apply each setting
+        errors = []
+        if "auto_reconnect" in body:
+            if not isinstance(body["auto_reconnect"], bool):
+                errors.append("auto_reconnect must be a boolean")
+        if "reconnect_interval_seconds" in body:
+            v = body["reconnect_interval_seconds"]
+            if not isinstance(v, int) or v < 5 or v > 600:
+                errors.append("reconnect_interval_seconds must be an integer between 5 and 600")
+        if "reconnect_max_backoff_seconds" in body:
+            v = body["reconnect_max_backoff_seconds"]
+            if not isinstance(v, int) or v < 60 or v > 3600:
+                errors.append("reconnect_max_backoff_seconds must be an integer between 60 and 3600")
+        if "scan_duration_seconds" in body:
+            v = body["scan_duration_seconds"]
+            if not isinstance(v, int) or v < 5 or v > 60:
+                errors.append("scan_duration_seconds must be an integer between 5 and 60")
+
+        if errors:
+            return web.json_response({"error": "; ".join(errors)}, status=400)
+
+        # Apply to live config
+        allowed = {"auto_reconnect", "reconnect_interval_seconds",
+                    "reconnect_max_backoff_seconds", "scan_duration_seconds"}
+        for key in allowed:
+            if key in body:
+                setattr(manager.config, key, body[key])
+
+        # Persist
+        manager.config.save_settings()
+
+        # Broadcast change to all WS clients
+        manager.event_bus.emit("settings_changed", manager.config.runtime_settings)
+
+        logger.info("Runtime settings updated: %s", manager.config.runtime_settings)
+        return web.json_response(manager.config.runtime_settings)
 
     @routes.get("/api/audio/sinks")
     async def audio_sinks(request: web.Request) -> web.Response:

--- a/bluetooth_audio_manager/rootfs/usr/src/bt_audio_manager/web/static/app.js
+++ b/bluetooth_audio_manager/rootfs/usr/src/bt_audio_manager/web/static/app.js
@@ -713,6 +713,39 @@ async function saveDeviceSettings() {
 }
 
 // ============================================
+// Section 11c: Add-on Settings Modal
+// ============================================
+
+async function openSettingsModal() {
+  try {
+    const data = await apiGet("/api/settings");
+    $("#setting-auto-reconnect").checked = data.auto_reconnect;
+    $("#setting-reconnect-interval").value = data.reconnect_interval_seconds;
+    $("#setting-reconnect-max-backoff").value = data.reconnect_max_backoff_seconds;
+    $("#setting-scan-duration").value = data.scan_duration_seconds;
+    new bootstrap.Modal("#settingsModal").show();
+  } catch (e) {
+    showToast(`Failed to load settings: ${e.message}`, "error");
+  }
+}
+
+async function saveSettings() {
+  const settings = {
+    auto_reconnect: $("#setting-auto-reconnect").checked,
+    reconnect_interval_seconds: parseInt($("#setting-reconnect-interval").value, 10),
+    reconnect_max_backoff_seconds: parseInt($("#setting-reconnect-max-backoff").value, 10),
+    scan_duration_seconds: parseInt($("#setting-scan-duration").value, 10),
+  };
+  try {
+    await apiPut("/api/settings", settings);
+    showToast("Settings saved", "success");
+    bootstrap.Modal.getInstance($("#settingsModal"))?.hide();
+  } catch (e) {
+    showToast(`Failed to save settings: ${e.message}`, "error");
+  }
+}
+
+// ============================================
 // Section 12: WebSocket (Real-time Updates)
 // ============================================
 
@@ -754,6 +787,9 @@ function connectWebSocket() {
         break;
       case "log_entry":
         appendLogEntry(msg);
+        break;
+      case "settings_changed":
+        // Runtime settings updated by another client; no action needed
         break;
       case "keepalive_changed":
         // Devices list will be re-sent via devices_changed; toast for feedback

--- a/bluetooth_audio_manager/rootfs/usr/src/bt_audio_manager/web/static/index.html
+++ b/bluetooth_audio_manager/rootfs/usr/src/bt_audio_manager/web/static/index.html
@@ -53,6 +53,9 @@
               <i class="fas fa-cog me-1"></i>Settings
             </button>
             <ul class="dropdown-menu dropdown-menu-end">
+              <li><a class="dropdown-item" href="#" onclick="openSettingsModal(); return false;">
+                <i class="fas fa-sliders me-2"></i>Add-on Settings
+              </a></li>
               <li><a class="dropdown-item" href="#" onclick="openAdaptersModal(); return false;">
                 <i class="fas fa-microchip me-2"></i>Bluetooth Adapters
               </a></li>
@@ -195,6 +198,65 @@
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ========== ADD-ON SETTINGS MODAL ========== -->
+  <div class="modal fade" id="settingsModal" tabindex="-1">
+    <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title"><i class="fas fa-sliders me-2"></i>Add-on Settings</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <!-- Auto Reconnect -->
+          <div class="mb-3">
+            <div class="form-check form-switch">
+              <input class="form-check-input" type="checkbox" id="setting-auto-reconnect">
+              <label class="form-check-label" for="setting-auto-reconnect">
+                <strong>Auto Reconnect</strong>
+              </label>
+            </div>
+            <div class="form-text">
+              Automatically reconnect to paired devices when they become available.
+            </div>
+          </div>
+
+          <!-- Reconnect Interval -->
+          <div class="mb-3">
+            <label for="setting-reconnect-interval" class="form-label">Reconnect Interval (seconds)</label>
+            <input type="number" class="form-control" id="setting-reconnect-interval" min="5" max="600" step="1">
+            <div class="form-text">
+              Initial delay between reconnection attempts (5&ndash;600).
+            </div>
+          </div>
+
+          <!-- Max Reconnect Backoff -->
+          <div class="mb-3">
+            <label for="setting-reconnect-max-backoff" class="form-label">Max Reconnect Backoff (seconds)</label>
+            <input type="number" class="form-control" id="setting-reconnect-max-backoff" min="60" max="3600" step="1">
+            <div class="form-text">
+              Maximum delay between reconnection attempts with exponential backoff (60&ndash;3600).
+            </div>
+          </div>
+
+          <!-- Scan Duration -->
+          <div class="mb-3">
+            <label for="setting-scan-duration" class="form-label">Scan Duration (seconds)</label>
+            <input type="number" class="form-control" id="setting-scan-duration" min="5" max="60" step="1">
+            <div class="form-text">
+              How long to scan for discoverable Bluetooth audio devices (5&ndash;60).
+            </div>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+          <button type="button" class="btn btn-primary" onclick="saveSettings()">
+            <i class="fas fa-save me-1"></i>Save
+          </button>
         </div>
       </div>
     </div>

--- a/bluetooth_audio_manager_dev/config.yaml
+++ b/bluetooth_audio_manager_dev/config.yaml
@@ -31,22 +31,12 @@ map:
   - type: data
     read_only: false
 
-# User options
+# User options (runtime settings are managed in the add-on UI)
 options:
   log_level: "info"
-  auto_reconnect: true
-  reconnect_interval_seconds: 30
-  reconnect_max_backoff_seconds: 300
-  scan_duration_seconds: 30
-  bt_adapter: "auto"
 
 schema:
   log_level: "list(debug|info|warning|error)"
-  auto_reconnect: bool
-  reconnect_interval_seconds: "int(5,600)"
-  reconnect_max_backoff_seconds: "int(60,3600)"
-  scan_duration_seconds: "int(5,60)"
-  bt_adapter: "str"
 
 apparmor: true
 watchdog: "http://[HOST]:[PORT:8099]/api/health"


### PR DESCRIPTION
## Summary
- Moves runtime settings (auto_reconnect, reconnect intervals, scan duration, bt_adapter) from the HAOS Configuration tab to the add-on's own web UI
- Settings now persist in `/data/settings.json` with automatic migration from `options.json` for upgrading users
- Only `log_level` remains on the HAOS config page
- Simplifies set-adapter API to write directly to `settings.json` instead of round-tripping through the Supervisor API
- Runtime settings (reconnect, scan) hot-reload without add-on restart

## Test plan
- [ ] Rebuild add-on — HAOS config page should only show `log_level`
- [ ] Open add-on UI → Settings → Add-on Settings — modal shows current values
- [ ] Change scan duration, save, trigger scan — new duration used without restart
- [ ] Change adapter via Bluetooth Adapters modal — persists after restart
- [ ] Fresh install (no `settings.json`) — defaults are created automatically
- [ ] Upgrade from older version with `options.json` settings — values migrate to `settings.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)