### PR TITLE
Fix Add Device tile layout and flying spinner bug

### DIFF
--- a/bluetooth_audio_manager/config.yaml
+++ b/bluetooth_audio_manager/config.yaml
@@ -1,5 +1,5 @@
 name: "Bluetooth Audio Manager"
-version: "0.1.99"
+version: "0.2.0"
 slug: bluetooth_audio_manager
 description: "Manage Bluetooth audio device connections (A2DP) with persistent pairing, auto-reconnect, and AppArmor security."
 url: "https://github.com/scyto/ha-bluetooth-audio-manager"

--- a/bluetooth_audio_manager/rootfs/usr/src/bt_audio_manager/web/static/app.js
+++ b/bluetooth_audio_manager/rootfs/usr/src/bt_audio_manager/web/static/app.js
@@ -162,19 +162,21 @@ function setScanningState(scanning, duration) {
 function updateAddDeviceTile() {
   const tile = $("#add-device-tile");
   if (!tile) return;
+  const body = tile.querySelector(".card-body");
+  if (!body) return;
   if (isScanning) {
     tile.classList.add("scanning");
     const label = scanSecondsRemaining > 0
-      ? `Scanning... ${scanSecondsRemaining}s`
-      : "Finishing...";
-    tile.innerHTML = `
-      <i class="fas fa-spinner fa-spin fa-2x mb-2"></i>
+      ? `Scanning\u2026 ${scanSecondsRemaining}s`
+      : "Finishing\u2026";
+    body.innerHTML = `
+      <i class="fas fa-spinner fa-spin"></i>
       <span>${label}</span>
     `;
   } else {
     tile.classList.remove("scanning");
-    tile.innerHTML = `
-      <i class="fas fa-plus fa-2x mb-2"></i>
+    body.innerHTML = `
+      <i class="fas fa-plus"></i>
       <span>Add Device</span>
     `;
   }
@@ -257,15 +259,15 @@ let currentSinks = [];
 
 function renderAddDeviceTile() {
   const scanLabel = isScanning
-    ? (scanSecondsRemaining > 0 ? `Scanning... ${scanSecondsRemaining}s` : "Finishing...")
+    ? (scanSecondsRemaining > 0 ? `Scanning\u2026 ${scanSecondsRemaining}s` : "Finishing\u2026")
     : "Add Device";
   const scanIcon = isScanning
-    ? '<i class="fas fa-spinner fa-spin fa-2x mb-2"></i>'
-    : '<i class="fas fa-plus fa-2x mb-2"></i>';
+    ? '<i class="fas fa-spinner fa-spin"></i>'
+    : '<i class="fas fa-plus"></i>';
   const scanClass = isScanning ? " scanning" : "";
   return `
-    <div class="col-md-6 col-lg-4">
-      <div class="card add-device-tile h-100${scanClass}" id="add-device-tile"
+    <div class="col-12 col-md-auto add-device-col">
+      <div class="card add-device-tile${scanClass}" id="add-device-tile"
            onclick="scanDevices()" role="button" tabindex="0"
            title="Scan for nearby Bluetooth audio devices">
         <div class="card-body">

--- a/bluetooth_audio_manager/rootfs/usr/src/bt_audio_manager/web/static/style.css
+++ b/bluetooth_audio_manager/rootfs/usr/src/bt_audio_manager/web/static/style.css
@@ -280,8 +280,13 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 /* ============================================
-   Add Device Tile
+   Add Device Tile (compact)
    ============================================ */
+
+.add-device-col {
+  flex: 0 0 auto;
+  width: auto;
+}
 
 .add-device-tile {
   border: 2px dashed var(--bs-border-color);
@@ -290,19 +295,24 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .add-device-tile .card-body {
-  min-height: 180px;
   display: flex;
-  flex-direction: column;
   align-items: center;
   justify-content: center;
+  gap: 0.5rem;
+  padding: 0.625rem 1.25rem;
   color: var(--bs-secondary-color);
   font-weight: 500;
+  font-size: 0.875rem;
+  white-space: nowrap;
+}
+
+.add-device-tile .card-body i {
+  font-size: 1rem;
 }
 
 .add-device-tile:hover {
-  transform: translateY(-2px);
+  transform: translateY(-1px);
   border-color: var(--accent-primary);
-  color: var(--accent-primary);
 }
 
 .add-device-tile:hover .card-body {


### PR DESCRIPTION
## Summary
- Compact Add Device tile: `col-auto` on desktop (sits to the left of device cards), `col-12` on mobile (full-width strip above cards)
- Fix flying spinner bug: `updateAddDeviceTile()` was replacing `tile.innerHTML` which destroyed the `.card-body` wrapper, causing the spinner icon to float outside the card and losing CSS centering
- Horizontal icon + text layout with smaller icon size
- Version bump 0.1.99 → 0.2.0

## Test plan
- [ ] Verify Add Device tile appears as compact element before first device card on desktop
- [ ] Verify tile is full-width on mobile (stacked above device cards)
- [ ] Click tile to scan — spinner and countdown text appear correctly inside the tile
- [ ] Verify no floating/flying spinner icons during scan
- [ ] Scan completes — tile restores to normal "Add Device" state
- [ ] Reconnect WebSocket mid-scan — tile syncs scanning state

🤖 Generated with [Claude Code](https://claude.com/claude-code)