### PR TITLE
Move Add Device button to left margin, out of grid

### DIFF
--- a/bluetooth_audio_manager/rootfs/usr/src/bt_audio_manager/web/static/app.js
+++ b/bluetooth_audio_manager/rootfs/usr/src/bt_audio_manager/web/static/app.js
@@ -265,8 +265,9 @@ function renderAddDeviceTile() {
     ? '<i class="fas fa-spinner fa-spin"></i>'
     : '<i class="fas fa-plus"></i>';
   const scanClass = isScanning ? " scanning" : "";
-  return `
-    <div class="col-12 col-md-auto add-device-col">
+  const wrapper = $("#add-device-wrapper");
+  if (wrapper) {
+    wrapper.innerHTML = `
       <div class="card add-device-tile${scanClass}" id="add-device-tile"
            onclick="scanDevices()" role="button" tabindex="0"
            title="Scan for nearby Bluetooth audio devices">
@@ -275,20 +276,20 @@ function renderAddDeviceTile() {
           <span>${scanLabel}</span>
         </div>
       </div>
-    </div>
-  `;
+    `;
+  }
 }
 
 function renderDevices(devices) {
   const grid = $("#devices-grid");
-  const tileHtml = renderAddDeviceTile();
+  renderAddDeviceTile();
 
   if (!devices || devices.length === 0) {
-    grid.innerHTML = tileHtml;
+    grid.innerHTML = "";
     return;
   }
 
-  grid.innerHTML = tileHtml + devices
+  grid.innerHTML = devices
     .map((d) => {
       const badgeClass = d.connected
         ? "badge-connected"

--- a/bluetooth_audio_manager/rootfs/usr/src/bt_audio_manager/web/static/index.html
+++ b/bluetooth_audio_manager/rootfs/usr/src/bt_audio_manager/web/static/index.html
@@ -91,9 +91,12 @@
           </button>
         </div>
       </div>
-      <div id="devices-grid" class="row g-3">
-        <div class="col-12 text-center py-5">
-          <p class="text-muted">Click "Scan" to discover nearby Bluetooth audio devices, or "Refresh" to see paired devices.</p>
+      <div class="devices-layout">
+        <div id="add-device-wrapper"></div>
+        <div id="devices-grid" class="row g-3">
+          <div class="col-12 text-center py-5">
+            <p class="text-muted">Click "Add Device" to discover nearby Bluetooth audio devices, or "Refresh" to see paired devices.</p>
+          </div>
         </div>
       </div>
     </div>

--- a/bluetooth_audio_manager/rootfs/usr/src/bt_audio_manager/web/static/style.css
+++ b/bluetooth_audio_manager/rootfs/usr/src/bt_audio_manager/web/static/style.css
@@ -280,17 +280,22 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 /* ============================================
-   Add Device Tile (compact)
+   Devices Layout (Add-Device in left margin)
    ============================================ */
 
-.add-device-col {
-  flex: 0 0 auto;
-  width: auto;
+.devices-layout {
+  position: relative;
+}
+
+/* Default: horizontal pill above the grid */
+#add-device-wrapper {
+  margin-bottom: 0.75rem;
 }
 
 .add-device-tile {
   border: 2px dashed var(--bs-border-color);
   cursor: pointer;
+  display: inline-block;
   transition: transform var(--transition-base), border-color var(--transition-base);
 }
 
@@ -299,7 +304,7 @@ h1, h2, h3, h4, h5, h6 {
   align-items: center;
   justify-content: center;
   gap: 0.5rem;
-  padding: 0.625rem 1.25rem;
+  padding: 0.5rem 1rem;
   color: var(--bs-secondary-color);
   font-weight: 500;
   font-size: 0.875rem;
@@ -331,6 +336,23 @@ h1, h2, h3, h4, h5, h6 {
 @keyframes scan-pulse {
   0%, 100% { border-color: var(--accent-primary); opacity: 1; }
   50% { border-color: var(--bs-border-color); opacity: 0.7; }
+}
+
+/* Wide screens: vertical button in the left margin */
+@media (min-width: 1440px) {
+  #add-device-wrapper {
+    position: absolute;
+    right: calc(100% + 0.75rem);
+    top: 0;
+    margin-bottom: 0;
+  }
+
+  .add-device-tile .card-body {
+    flex-direction: column;
+    gap: 0.25rem;
+    padding: 0.75rem 0.5rem;
+    font-size: 0.75rem;
+  }
 }
 
 /* ============================================


### PR DESCRIPTION
## Summary
- Pull Add Device button out of `#devices-grid` entirely so device tiles align under the "Devices" header as before
- Wide screens (≥1440px): button positioned absolutely in the left margin as a vertical pill (icon + text stacked)
- Narrower screens / mobile: horizontal pill above the grid
- New `.devices-layout` wrapper with `position: relative` for margin positioning

## Test plan
- [ ] Device tiles align properly under "Devices" header (no grid shift)
- [ ] Wide screen: Add Device button visible in the left margin, vertical layout
- [ ] Narrow/mobile: Add Device button appears above the grid, horizontal layout
- [ ] Scanning state (spinner + countdown) works in both layouts
- [ ] Tile restores to "Add Device" after scan completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)