### PR TITLE
Align UI style with Multi-Room Audio design patterns

### DIFF
--- a/bluetooth_audio_manager/config.yaml
+++ b/bluetooth_audio_manager/config.yaml
@@ -1,5 +1,5 @@
 name: "Bluetooth Audio Manager"
-version: "0.2.0"
+version: "0.2.1"
 slug: bluetooth_audio_manager
 description: "Manage Bluetooth audio device connections (A2DP) with persistent pairing, auto-reconnect, and AppArmor security."
 url: "https://github.com/scyto/ha-bluetooth-audio-manager"

--- a/bluetooth_audio_manager/rootfs/usr/src/bt_audio_manager/web/static/index.html
+++ b/bluetooth_audio_manager/rootfs/usr/src/bt_audio_manager/web/static/index.html
@@ -20,15 +20,12 @@
   <div class="app-header text-white py-4 mb-4">
     <div class="container">
       <div class="row align-items-center">
-        <div class="col d-flex align-items-center gap-3">
-          <img src="static/logo.png" alt="Logo" class="header-logo">
-          <div>
-            <h1 class="mb-0">Bluetooth Audio Manager</h1>
-            <p class="mb-0 opacity-75">Manage Bluetooth audio device connections</p>
-            <div class="build-info">
-              <span class="build-label">Build</span>
-              <span id="build-version" class="build-version">loading...</span>
-            </div>
+        <div class="col">
+          <h1 class="mb-0"><i class="fab fa-bluetooth-b me-2"></i>Bluetooth Audio Manager</h1>
+          <p class="mb-0 opacity-75">Manage Bluetooth audio device connections</p>
+          <div class="build-info">
+            <span class="build-label">Build</span>
+            <span id="build-version" class="build-version">loading...</span>
           </div>
         </div>
         <div class="col-auto">
@@ -182,6 +179,12 @@
           <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
         </div>
         <div class="modal-body">
+          <div class="alert alert-warning">
+            <i class="fas fa-exclamation-triangle me-2"></i>
+            <strong>Recommendation:</strong> Use a dedicated Bluetooth adapter that is
+            <strong>not configured in Home Assistant</strong> and is not used for BLE scanning.
+            Leave the adapter unconfigured in HA &mdash; this add-on will manage it directly.
+          </div>
           <p class="text-muted">
             Select which Bluetooth adapter to use. Changing the adapter requires an add-on restart.
           </p>

--- a/bluetooth_audio_manager/rootfs/usr/src/bt_audio_manager/web/static/style.css
+++ b/bluetooth_audio_manager/rootfs/usr/src/bt_audio_manager/web/static/style.css
@@ -163,12 +163,6 @@ h1, h2, h3, h4, h5, h6 {
   transition: background var(--transition-fast);
 }
 
-.header-logo {
-  width: 40px;
-  height: 40px;
-  border-radius: var(--radius-md);
-}
-
 /* Build info pill */
 .build-info {
   display: inline-flex;
@@ -256,7 +250,7 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 /* ============================================
-   Operation Banner
+   Operation Banner (translucent alert style)
    ============================================ */
 
 .operation-banner {
@@ -264,9 +258,9 @@ h1, h2, h3, h4, h5, h6 {
   justify-content: center;
   gap: 0.5rem;
   padding: 0.75rem 1rem;
-  background: var(--bs-info-bg-subtle);
-  border-bottom: 2px solid var(--accent-primary);
-  color: var(--bs-info-text-emphasis);
+  background: rgba(59, 130, 246, 0.1);
+  color: var(--bs-body-color);
+  font-size: 0.9375rem;
 }
 
 .operation-banner:not(.d-none) {
@@ -277,6 +271,36 @@ h1, h2, h3, h4, h5, h6 {
   width: 1rem;
   height: 1rem;
   border-width: 0.15em;
+}
+
+/* ============================================
+   Alert overrides (borderless, translucent)
+   ============================================ */
+
+.alert {
+  border-radius: var(--radius-md);
+  border: none;
+  font-size: 0.9375rem;
+}
+
+.alert-info {
+  background: rgba(59, 130, 246, 0.1);
+  color: var(--bs-body-color);
+}
+
+.alert-success {
+  background: rgba(16, 185, 129, 0.1);
+  color: var(--bs-body-color);
+}
+
+.alert-warning {
+  background: rgba(245, 158, 11, 0.1);
+  color: var(--bs-body-color);
+}
+
+.alert-danger {
+  background: rgba(239, 68, 68, 0.1);
+  color: var(--bs-body-color);
 }
 
 /* ============================================
@@ -747,11 +771,6 @@ h1, h2, h3, h4, h5, h6 {
   .app-header .btn {
     padding: 0.5rem 0.75rem;
     font-size: 0.8125rem;
-  }
-
-  .header-logo {
-    width: 32px;
-    height: 32px;
   }
 
   .logs-container {


### PR DESCRIPTION
## Summary
- **Header**: Replace PNG logo with Font Awesome Bluetooth icon (`fa-bluetooth-b`) inline in `<h1>`, matching Multi-Room Audio's icon-in-title layout
- **Adapters modal**: Add `alert-warning` recommending a dedicated BT adapter not managed by HA and not used for BLE scanning
- **Operation banner**: Restyle with translucent 10% opacity background instead of opaque `info-bg-subtle` + border, matching Multi-Room Audio's alert style
- **Alert overrides**: All alert variants (info, success, warning, danger) use borderless, translucent colored backgrounds that adapt to light/dark theme

## Test plan
- [ ] Header shows Bluetooth icon inline with title text (no separate logo image)
- [ ] Open Bluetooth Adapters modal — warning banner visible at top
- [ ] Trigger an operation (pair/connect) — status banner uses subtle translucent style
- [ ] Both light and dark themes render alerts correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)