### PR TITLE
Fix adapter friendly names via sysfs USB IDs

### DIFF
--- a/bluetooth_audio_manager/config.yaml
+++ b/bluetooth_audio_manager/config.yaml
@@ -1,5 +1,5 @@
 name: "Bluetooth Audio Manager"
-version: "0.2.5"
+version: "0.2.6"
 slug: bluetooth_audio_manager
 description: "Manage Bluetooth audio device connections (A2DP) with persistent pairing, auto-reconnect, and AppArmor security."
 url: "https://github.com/scyto/ha-bluetooth-audio-manager"

--- a/src/bt_audio_manager/manager.py
+++ b/src/bt_audio_manager/manager.py
@@ -806,8 +806,9 @@ class BluetoothAudioManager:
                     if hci_key in usb_names:
                         a["hw_model"] = usb_names[hci_key]
                         continue
-                    # Try match by Modalias → USB vendor:product
-                    usb_id = self._modalias_to_usb_id(a["modalias"])
+                    # Try match by real USB ID from sysfs (preferred),
+                    # fall back to modalias-derived ID (less reliable in Docker)
+                    usb_id = a.get("usb_id") or self._modalias_to_usb_id(a["modalias"])
                     if usb_id and usb_id in usb_names:
                         a["hw_model"] = usb_names[usb_id]
 

--- a/src/bt_audio_manager/web/static/app.js
+++ b/src/bt_audio_manager/web/static/app.js
@@ -467,10 +467,10 @@ function renderAdaptersModal(adapters) {
         : '<span class="badge bg-secondary">Off</span>';
 
       // Friendly name: prefer resolved hw_model (not raw modalias), else alias
+      // Filter out hostname-like aliases (contain dots) — BlueZ defaults alias to hostname
       const hwResolved = a.hw_model && a.hw_model !== a.modalias;
-      const friendlyName = hwResolved
-        ? a.hw_model
-        : (a.alias && a.alias !== a.name ? a.alias : "");
+      const aliasUseful = a.alias && a.alias !== a.name && !a.alias.includes(".");
+      const friendlyName = hwResolved ? a.hw_model : (aliasUseful ? a.alias : "");
 
       // Technical line: hci name + modalias
       const techParts = [a.name];


### PR DESCRIPTION
## Summary
- Read real USB `idVendor`/`idProduct` from sysfs instead of relying on BlueZ `Modalias` (which reports the wrong USB root hub ID inside Docker containers)
- Use sysfs-derived USB IDs for Supervisor hardware name matching, with modalias as fallback
- Filter out hostname-like BlueZ aliases (e.g. `homeassistant.alexbal.com`) in the adapter UI

## Root Cause
BlueZ's `Modalias` property inside Docker containers reports the USB root hub ID (`usb:v1D6Bp0246d0555`) for **all** adapters instead of their actual USB device IDs. This caused our Supervisor enrichment matching to fail, so adapters showed raw modalias strings or useless hostname aliases instead of friendly names like "TP-Link UB500 Adapter".

The fix reads `idVendor`/`idProduct` files from `/sys/class/bluetooth/hciX/device/` — these always contain the correct USB IDs for USB-connected adapters.

## Test plan
- [ ] Open Bluetooth Adapters modal — adapters should show resolved USB product names as the primary bold name
- [ ] Technical line should show `hci0 — usb:v1D6Bp0246d0555` (the BlueZ modalias, for reference)
- [ ] Check add-on logs for `Supervisor HW names:` — should show correct USB ID → name mappings
- [ ] Non-USB adapters (if any) should fall back gracefully to modalias display

🤖 Generated with [Claude Code](https://claude.com/claude-code)