### PR TITLE
Fix blank manufacturer in sysfs hw_info causing leading space

### DIFF
--- a/src/bt_audio_manager/bluez/adapter.py
+++ b/src/bt_audio_manager/bluez/adapter.py
@@ -248,13 +248,16 @@ class BluezAdapter:
             for path in [device_path, os.path.dirname(device_path)]:
                 mfr_file = os.path.join(path, "manufacturer")
                 prod_file = os.path.join(path, "product")
-                if os.path.isfile(mfr_file) and os.path.isfile(prod_file):
-                    mfr = open(mfr_file).read().strip()
-                    prod = open(prod_file).read().strip()
-                    return f"{mfr} {prod}"
-                # Some devices only have product
                 if os.path.isfile(prod_file):
-                    return open(prod_file).read().strip()
+                    prod = open(prod_file).read().strip()
+                    if not prod:
+                        continue
+                    # Include manufacturer only if non-empty
+                    if os.path.isfile(mfr_file):
+                        mfr = open(mfr_file).read().strip()
+                        if mfr:
+                            return f"{mfr} {prod}"
+                    return prod
         except OSError:
             pass
         return None


### PR DESCRIPTION
## Summary
- Skip empty manufacturer string when building hw_model from sysfs, preventing "  TP-Link UB500 Adapter" (leading space)
- Some USB devices (e.g. TP-Link UB500) have a manufacturer file containing only whitespace

## Context
Continues adapter friendly name fixes. After AppArmor fix (on main) and two-pass Supervisor enrichment (#47), sysfs reads now work. Two of three adapters get names from sysfs (`product` file). The Intel adapter (8087:0033) has no sysfs string descriptors and relies on Supervisor API enrichment.

## Test plan
- [ ] hci0 shows "TP-Link UB500 Adapter" (no leading space)
- [ ] hci2 shows "CSR8510 A10"
- [ ] hci1 (Intel) shows name from Supervisor enrichment

🤖 Generated with [Claude Code](https://claude.com/claude-code)