### PR TITLE
Log Supervisor hardware API failures at WARNING level

### DIFF
--- a/src/bt_audio_manager/manager.py
+++ b/src/bt_audio_manager/manager.py
@@ -834,6 +834,7 @@ class BluetoothAudioManager:
         import re
         token = os.environ.get("SUPERVISOR_TOKEN")
         if not token:
+            logger.warning("SUPERVISOR_TOKEN not set — cannot query hardware API")
             return {}
         try:
             async with aiohttp.ClientSession() as session:
@@ -842,6 +843,7 @@ class BluetoothAudioManager:
                     headers={"Authorization": f"Bearer {token}"},
                 ) as resp:
                     if resp.status != 200:
+                        logger.warning("Supervisor hardware API returned %s", resp.status)
                         return {}
                     result = await resp.json()
 
@@ -923,7 +925,7 @@ class BluetoothAudioManager:
                                  if any(kw in k.upper() for kw in ("VENDOR", "MODEL", "PRODUCT", "ID_"))})
             return names
         except Exception as e:
-            logger.debug("Failed to query Supervisor hardware API: %s", e)
+            logger.warning("Failed to query Supervisor hardware API: %s", e)
             return {}
 
     @staticmethod


### PR DESCRIPTION
## Summary
- Changed Supervisor hardware API failure logging from DEBUG to WARNING level
- Now visible at default INFO log level: missing token, non-200 responses, exceptions
- Previously silent failures made it impossible to diagnose why Intel adapter (8087:0033) wasn't getting a friendly name from the Supervisor enrichment

## Test plan
- [ ] Check add-on logs after restart — should now show either `Supervisor HW names: {...}` (success) or a WARNING explaining why it failed
- [ ] Intel adapter (hci1) should show friendly name if Supervisor API succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)