### PR TITLE
Fix debug logging feedback loop and suppress noisy RSSI events

### DIFF
--- a/src/bt_audio_manager/manager.py
+++ b/src/bt_audio_manager/manager.py
@@ -108,13 +108,12 @@ class BluetoothAudioManager:
                     changed = msg.body[1] if len(msg.body) > 1 else {}
                     prop_names = list(changed.keys()) if isinstance(changed, dict) else []
 
-                    # Suppress noisy RSSI / ManufacturerData spam to DEBUG
+                    # Silently discard noisy RSSI / ManufacturerData / TxPower
+                    # churn — these fire many times per second per device and
+                    # provide no actionable information for this add-on.
                     _NOISY_PROPS = {"RSSI", "ManufacturerData", "TxPower"}
                     if iface_name == "org.bluez.Device1" and set(prop_names) <= _NOISY_PROPS:
-                        logger.debug(
-                            "BlueZ PropertiesChanged: iface=%s props=%s path=%s",
-                            iface_name, prop_names, msg.path,
-                        )
+                        pass
                     else:
                         logger.info(
                             "BlueZ PropertiesChanged: iface=%s props=%s path=%s",

--- a/src/bt_audio_manager/web/log_handler.py
+++ b/src/bt_audio_manager/web/log_handler.py
@@ -17,11 +17,18 @@ class WebSocketLogHandler(logging.Handler):
     def __init__(self, event_bus: EventBus) -> None:
         super().__init__()
         self._event_bus = event_bus
+        self._emitting = False
         self.recent_logs: collections.deque[dict] = collections.deque(
             maxlen=self.MAX_RECENT_LOGS,
         )
 
     def emit(self, record: logging.LogRecord) -> None:
+        # Re-entrancy guard: EventBus.emit() may log at DEBUG level,
+        # which would call back into this handler and create an infinite
+        # loop (log → event → log → event → …).  Drop nested records.
+        if self._emitting:
+            return
+        self._emitting = True
         try:
             entry = {
                 "ts": record.created,
@@ -33,3 +40,5 @@ class WebSocketLogHandler(logging.Handler):
             self._event_bus.emit("log_entry", entry)
         except Exception:
             self.handleError(record)
+        finally:
+            self._emitting = False


### PR DESCRIPTION
## Summary
- **Fix EventBus feedback loop**: When `log_level=debug`, `WebSocketLogHandler.emit()` → `EventBus.emit("log_entry")` → `logger.debug()` → back to handler, creating an infinite loop that fills the event queue and makes the container non-operational. Added a re-entrancy guard (`_emitting` flag) to drop nested log records.
- **Suppress RSSI/ManufacturerData/TxPower signals**: These `PropertiesChanged` signals fire many times per second per device and provide no actionable information. Previously logged at DEBUG level (which fed the loop above). Now silently discarded.

## Test plan
- [ ] Set `log_level` to `debug` in add-on config
- [ ] Restart add-on — verify it stays operational and UI loads
- [ ] Check logs — no flood of "Dropping event 'log_entry'" warnings
- [ ] Verify RSSI/ManufacturerData/TxPower signals no longer appear in logs
- [ ] Set `log_level` back to `info` — verify normal operation

🤖 Generated with [Claude Code](https://claude.com/claude-code)