### PR TITLE
Enable Supervisor API access for adapter name enrichment

### DIFF
--- a/bluetooth_audio_manager/config.yaml
+++ b/bluetooth_audio_manager/config.yaml
@@ -15,6 +15,7 @@ boot: auto
 
 # Permissions (least privilege)
 host_dbus: true
+hassio_api: true
 audio: true
 privileged:
   - NET_ADMIN

--- a/bluetooth_audio_manager_dev/config.yaml
+++ b/bluetooth_audio_manager_dev/config.yaml
@@ -15,6 +15,7 @@ boot: auto
 
 # Permissions (least privilege)
 host_dbus: true
+hassio_api: true
 audio: true
 privileged:
   - NET_ADMIN


### PR DESCRIPTION
## Summary
- Adds `hassio_api: true` to both stable and dev `config.yaml` files
- This grants the add-on permission to call the Supervisor REST API (e.g. `/hardware/info`)
- Without this flag, the Supervisor blocked all connections — causing "Cannot connect to host supervisor:80" errors that prevented adapters without sysfs string descriptors (like Intel 8087:0033) from getting friendly USB product names

## Root cause
The `SUPERVISOR_TOKEN` env var is always injected into add-on containers, but the Supervisor only allows API calls from add-ons that declare `hassio_api: true`. The default role (`default`) is sufficient for the read-only `/hardware/info` endpoint we use.

## Test plan
- [ ] After `ha addons reload` + restart, check logs for `Supervisor HW names:` line with resolved names
- [ ] Open Bluetooth Adapters modal — Intel adapter should now show "Intel Corp. Wireless-AC 9260" (or similar) instead of just the modalias
- [ ] Verify the restart button (which uses `/addons/self/restart`) still works (it's on the always-allowed bypass list)

🤖 Generated with [Claude Code](https://claude.com/claude-code)