### PR TITLE
Fix DNS resolution in AppArmor and add Supervisor IP fallback

### DIFF
--- a/bluetooth_audio_manager/apparmor.txt
+++ b/bluetooth_audio_manager/apparmor.txt
@@ -63,6 +63,12 @@ profile bluetooth_audio_manager flags=(attach_disconnected,mediate_deleted) {
   /usr/lib/libdbus* r,
   /lib/** r,
 
+  # DNS resolution (required for Supervisor API calls via hostname)
+  /etc/resolv.conf r,
+  /etc/nsswitch.conf r,
+  /etc/hosts r,
+  /etc/host.conf r,
+
   # Read-only system info
   /proc/*/status r,
   /sys/class/bluetooth/** r,

--- a/bluetooth_audio_manager_dev/apparmor.txt
+++ b/bluetooth_audio_manager_dev/apparmor.txt
@@ -63,6 +63,12 @@ profile bluetooth_audio_manager flags=(attach_disconnected,mediate_deleted) {
   /usr/lib/libdbus* r,
   /lib/** r,
 
+  # DNS resolution (required for Supervisor API calls via hostname)
+  /etc/resolv.conf r,
+  /etc/nsswitch.conf r,
+  /etc/hosts r,
+  /etc/host.conf r,
+
   # Read-only system info
   /proc/*/status r,
   /sys/class/bluetooth/** r,


### PR DESCRIPTION
## Summary
- **Root cause**: AppArmor profile blocked `/etc/resolv.conf`, breaking DNS resolution entirely — the `supervisor` hostname couldn't be resolved
- **AppArmor fix**: Added rules for `/etc/resolv.conf`, `/etc/hosts`, `/etc/nsswitch.conf`, `/etc/host.conf` in both stable and dev profiles
- **Code fallback**: Try `http://supervisor/` first, fall back to `http://172.30.32.2/` (standard Supervisor IP) with a 5-second timeout per attempt

## Evidence
```
# From inside the running container:
$ cat /etc/resolv.conf → Permission denied
$ nslookup supervisor → parse of /etc/resolv.conf failed
$ wget http://172.30.32.2/info → 401 Unauthorized (reachable by IP!)
```

## Test plan
- [ ] After `ha addons reload` + restart, check that `Supervisor HW names:` log line appears with resolved names
- [ ] Intel adapter (hci1, 8087:0033) should show a friendly USB product name
- [ ] Even before AppArmor reload, the IP fallback should work immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)