### PR TITLE
Add clean adapter switch with device cleanup

### DIFF
--- a/src/bt_audio_manager/web/static/app.js
+++ b/src/bt_audio_manager/web/static/app.js
@@ -810,14 +810,45 @@ async function forgetDevice(address) {
   }
 }
 
+let _pendingAdapterName = null;
+
 async function selectAdapter(adapterName) {
-  if (!confirm(`Switch to adapter ${adapterName}? The add-on will restart.`)) return;
+  // If no devices are stored/paired, skip the warning — nothing to lose
+  const hasDevices = lastDevices && lastDevices.some((d) => d.stored || d.paired);
+  if (!hasDevices) {
+    await doAdapterSwitch(adapterName, false);
+    return;
+  }
+
+  // Show confirmation modal with pairing-loss warning
+  _pendingAdapterName = adapterName;
+  $("#switch-adapter-name").textContent = adapterName;
+  new bootstrap.Modal("#adapterSwitchModal").show();
+}
+
+async function doAdapterSwitch(adapterName, clean) {
   try {
-    showBanner(`Switching to adapter ${adapterName}...`);
-    const result = await apiPost("/api/set-adapter", { adapter: adapterName });
+    // Close both modals — they will have stale data until the server returns
+    bootstrap.Modal.getInstance($("#adapterSwitchModal"))?.hide();
+    bootstrap.Modal.getInstance($("#adaptersModal"))?.hide();
+    showBanner(
+      clean
+        ? `Cleaning devices and switching to ${adapterName}...`
+        : `Switching to adapter ${adapterName}...`
+    );
+
+    // Backend handles disconnect-all + forget-all when clean=true,
+    // and pushes live progress via WebSocket status messages.
+    const result = await apiPost("/api/set-adapter", {
+      adapter: adapterName,
+      clean: clean,
+    });
     if (result.restart_required) {
       showBanner("Restarting add-on with new adapter...");
-      await apiPost("/api/restart");
+      // Fire-and-forget: the server will die during restart, so the
+      // response will never arrive (expected 502). The WebSocket
+      // reconnect loop will detect when the server is back.
+      apiPost("/api/restart").catch(() => {});
     }
   } catch (e) {
     hideBanner();
@@ -914,6 +945,7 @@ function connectWebSocket() {
     console.log("[WS] Connected");
     wsReconnectDelay = 1000;
     hideReconnectBanner();
+    hideBanner(); // Clear any pending operation banner (e.g. adapter restart)
     setConnectionStatus("connected");
   };
 
@@ -1025,6 +1057,17 @@ document.addEventListener("DOMContentLoaded", () => {
   // Wire up keep-alive toggle in device settings modal
   const kaToggle = $("#setting-keep-alive-enabled");
   if (kaToggle) kaToggle.addEventListener("change", toggleKeepAliveMethodVisibility);
+
+  // Wire up adapter-switch confirmation button
+  const confirmSwitchBtn = $("#btn-confirm-adapter-switch");
+  if (confirmSwitchBtn) {
+    confirmSwitchBtn.addEventListener("click", async () => {
+      if (!_pendingAdapterName) return;
+      const name = _pendingAdapterName;
+      _pendingAdapterName = null;
+      await doAdapterSwitch(name, true);
+    });
+  }
 
   // WebSocket provides real-time updates (initial state sent on connect)
   connectWebSocket();

--- a/src/bt_audio_manager/web/static/index.html
+++ b/src/bt_audio_manager/web/static/index.html
@@ -210,6 +210,39 @@
     </div>
   </div>
 
+  <!-- ========== ADAPTER SWITCH CONFIRMATION MODAL ========== -->
+  <div class="modal fade" id="adapterSwitchModal" tabindex="-1">
+    <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-content">
+        <div class="modal-header bg-warning-subtle">
+          <h5 class="modal-title">
+            <i class="fas fa-exclamation-triangle text-warning me-2"></i>Switch Bluetooth Adapter
+          </h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <p>You are about to switch to adapter <strong id="switch-adapter-name"></strong>.</p>
+          <div class="alert alert-warning mb-3">
+            <i class="fas fa-info-circle me-2"></i>
+            Bluetooth pairings are tied to a specific adapter. Switching adapters means
+            <strong>all current device pairings will be removed</strong> and devices will need
+            to be re-paired on the new adapter.
+          </div>
+          <p class="mb-0 text-muted small">
+            All connected devices will be disconnected and removed before the add-on restarts
+            with the new adapter.
+          </p>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+          <button type="button" class="btn btn-warning" id="btn-confirm-adapter-switch">
+            <i class="fas fa-exchange-alt me-1"></i>Switch &amp; Clear Pairings
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <!-- ========== ADD-ON SETTINGS MODAL ========== -->
   <div class="modal fade" id="settingsModal" tabindex="-1">
     <div class="modal-dialog modal-dialog-centered">


### PR DESCRIPTION
## Summary
- Adds a confirmation modal warning users that **all device pairings will be lost** when switching Bluetooth adapters (BlueZ pairings are per-adapter MAC)
- Before switching: disconnects all active devices, removes them from BlueZ, clears the persistent store, then saves the new adapter and restarts
- Fixes the 502 error that appeared during adapter restart (fire-and-forget the restart call since the server will die)

## Test plan
- [ ] Pair a device on the current adapter, then switch adapters — confirm warning modal appears
- [ ] Click "Switch & Clear Pairings" — verify banner shows live progress (disconnecting, removing, restarting)
- [ ] After restart: device list is empty, new adapter is active, no 502 error
- [ ] Cancel the confirmation modal — verify nothing changes
- [ ] Switch adapters with no devices paired — verify it skips the warning and switches directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)