### PR TITLE
Use MAC address for stable adapter identification

### DIFF
--- a/src/bt_audio_manager/config.py
+++ b/src/bt_audio_manager/config.py
@@ -43,18 +43,14 @@ class AppConfig:
     scan_duration_seconds: int = 30
 
     @property
-    def adapter_path(self) -> str:
-        """Resolve the bt_adapter setting to a BlueZ D-Bus adapter path.
+    def bt_adapter_is_mac(self) -> bool:
+        """True when bt_adapter stores a MAC address (new format)."""
+        return ":" in self.bt_adapter
 
-        "auto" → "/org/bluez/hci0" (default first adapter).
-        "hci1" → "/org/bluez/hci1", etc.
-        """
-        if self.bt_adapter == "auto":
-            return "/org/bluez/hci0"
-        name = self.bt_adapter
-        if name.startswith("/org/bluez/"):
-            return name
-        return f"/org/bluez/{name}"
+    @property
+    def bt_adapter_is_legacy_hci(self) -> bool:
+        """True when bt_adapter stores a legacy HCI name like 'hci1'."""
+        return self.bt_adapter != "auto" and ":" not in self.bt_adapter
 
     @property
     def runtime_settings(self) -> dict:

--- a/src/bt_audio_manager/web/api.py
+++ b/src/bt_audio_manager/web/api.py
@@ -71,11 +71,14 @@ def create_api_routes(
     async def info(request: web.Request) -> web.Response:
         """Return add-on version and adapter info for the UI."""
         import os
-        adapter_name = manager._adapter_path.rsplit("/", 1)[-1]
+        path = manager._adapter_path or "/org/bluez/hci0"
+        adapter_name = path.rsplit("/", 1)[-1]
         return web.json_response({
             "version": os.environ.get("BUILD_VERSION", "dev"),
             "adapter": adapter_name,
-            "adapter_path": manager._adapter_path,
+            "adapter_path": path,
+            "adapter_mac": manager.config.bt_adapter
+            if manager.config.bt_adapter_is_mac else None,
         })
 
     @routes.get("/api/adapters")


### PR DESCRIPTION
## Summary
- HCI indexes are not stable across reboots — they shift when adapters are added/removed. Switch to storing the **adapter MAC address** in `settings.json` instead of the HCI name
- On startup, enumerates all adapters via D-Bus and resolves MAC → current HCI path
- Auto-migrates legacy `"hci1"` settings to MAC on first boot
- Falls back to auto if configured adapter is missing (preserves settings for when it's reconnected)
- Frontend sends MAC address on adapter select, shows friendly name in UI

Follows up on #55 (clean adapter switch).

## Test plan
- [ ] Select an adapter — verify `settings.json` stores a MAC address
- [ ] Reboot — verify it resolves to the correct adapter even if HCI index shifted
- [ ] Unplug selected adapter → restart — verify fallback to auto with warning, settings preserved
- [ ] Plug adapter back in → restart — verify it reconnects to correct adapter
- [ ] Legacy migration: write `"bt_adapter": "hci1"` in settings.json → restart → verify migration to MAC

🤖 Generated with [Claude Code](https://claude.com/claude-code)