### PR TITLE
Fix A2DP sink not appearing after pairing

### DIFF
--- a/src/bt_audio_manager/bluez/device.py
+++ b/src/bt_audio_manager/bluez/device.py
@@ -288,6 +288,13 @@ class BluezDevice:
             )
             if resolved.value:
                 return True
+            # Bail out early if device disconnected
+            connected = await self._properties_iface.call_get(
+                DEVICE_INTERFACE, "Connected"
+            )
+            if not connected.value:
+                logger.warning("Device %s disconnected while waiting for services", self._address)
+                return False
             await asyncio.sleep(0.5)
         logger.warning("Services not resolved for %s within %ss", self._address, timeout)
         return False


### PR DESCRIPTION
## Summary
- **Always call `device.connect()`** even when already connected after pairing — BlueZ's pair auto-connect only creates a link-level connection; the explicit `Connect()` D-Bus call is needed to establish A2DP profiles
- **Suppress reconnect service** during active pair/connect flows to prevent competing reconnect tasks
- **Add disconnect detection** to `wait_for_services()` and `wait_for_bt_sink()` so they bail out early instead of polling for 15+ seconds when the device has already disconnected

## Test plan
- [ ] Build dev container and deploy to HA
- [ ] Remove all paired devices (clean slate)
- [ ] Pair a new speaker — should connect and create A2DP sink in one step (no manual connect needed)
- [ ] Switch adapters — pair the same speaker on the new adapter — should also work first try
- [ ] Check logs: should see `connect()` called even when already connected, no "A2DP sink did not appear" warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)