### PR TITLE
Rename add-on to app per HA 2026.2

### DIFF
--- a/.github/ISSUE_TEMPLATE/device-issue.yml
+++ b/.github/ISSUE_TEMPLATE/device-issue.yml
@@ -49,7 +49,7 @@ body:
   - type: input
     id: addon-version
     attributes:
-      label: Add-on version
+      label: App version
       placeholder: e.g. 0.3.5
     validations:
       required: true

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -159,10 +159,10 @@ jobs:
           cache-to: type=gha,scope=dev-${{ matrix.arch }},mode=max
 
   # ==========================================================================
-  # Update dev add-on version on main (after successful dev build)
+  # Update dev app version on main (after successful dev build)
   # ==========================================================================
   update-addon-version-dev:
-    name: Update dev add-on version
+    name: Update dev app version
     needs: build-dev
     if: github.ref == 'refs/heads/dev'
     runs-on: ubuntu-latest
@@ -195,7 +195,7 @@ jobs:
           if git diff --staged --quiet; then
             echo "No version change needed"
           else
-            git commit -m "chore: update dev add-on version to sha-$(echo "${{ github.sha }}" | cut -c1-7) [skip ci]"
+            git commit -m "chore: update dev app version to sha-$(echo "${{ github.sha }}" | cut -c1-7) [skip ci]"
             git push origin main
-            echo "Dev add-on version bump committed to main"
+            echo "Dev app version bump committed to main"
           fi

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # ha-bluetooth-audio-manager
-Home Assistant add-on for managing Bluetooth audio device connections (A2DP) with persistent pairing, auto-reconnect, and AppArmor security.
+Home Assistant app for managing Bluetooth audio device connections (A2DP) with persistent pairing, auto-reconnect, and AppArmor security.
 
 ## THIS IS A TESTING HARNESS AT THIS TIME DO NOT USE AND NO ISSUES WILL BE ACCEPTED

--- a/bluetooth_audio_manager/DOCS.md
+++ b/bluetooth_audio_manager/DOCS.md
@@ -5,7 +5,7 @@ persistent pairing, automatic reconnection, and a web-based management UI.
 
 ## How it works
 
-This add-on uses BlueZ (the Linux Bluetooth stack) via D-Bus to discover,
+This app uses BlueZ (the Linux Bluetooth stack) via D-Bus to discover,
 pair, and connect Bluetooth audio devices. Once connected, the device appears
 as a PulseAudio sink that Home Assistant's audio system can use for TTS,
 media playback, and automations.
@@ -20,7 +20,7 @@ media playback, and automations.
 
 ## Coexistence with Home Assistant Bluetooth
 
-This add-on is designed to coexist safely with Home Assistant's built-in
+This app is designed to coexist safely with Home Assistant's built-in
 Bluetooth integration (used for BLE sensors, beacons, etc.):
 
 - Discovery uses `Transport=bredr` (Classic Bluetooth only), while HA scans
@@ -56,7 +56,7 @@ Two methods are available:
 
 ## Usage
 
-1. Open the add-on from the Home Assistant sidebar ("BT Audio")
+1. Open the app from the Home Assistant sidebar ("BT Audio")
 2. Click **Scan for Devices** (make sure your speaker is in pairing mode)
 3. Click **Pair** next to your device
 4. Click **Connect** — the device will appear as a PulseAudio audio sink
@@ -66,7 +66,7 @@ Two methods are available:
 ## Requirements
 
 - A Bluetooth adapter (built-in or USB dongle) accessible to HAOS
-- The Bluetooth adapter must be powered on (managed by HAOS, not this add-on)
+- The Bluetooth adapter must be powered on (managed by HAOS, not this app)
 - The target device must support A2DP (Advanced Audio Distribution Profile)
 
 ## Troubleshooting
@@ -85,15 +85,15 @@ UI (device menu > Settings). Try the `infrasound` method if `silence` doesn't
 work.
 
 **`br-connection-key-missing` error when connecting**: The pairing keys stored
-by BlueZ are out of sync with the speaker. Click **Forget** in the add-on UI,
+by BlueZ are out of sync with the speaker. Click **Forget** in the app UI,
 then clear the pairing on the speaker itself (usually hold the Bluetooth button
 for ~10 seconds until the speaker announces "ready to pair" or the LED enters
-pairing mode). Then scan and pair again from the add-on.
+pairing mode). Then scan and pair again from the app.
 
 **`Authentication Rejected` when pairing**: The speaker still has old pairing
 keys for your system's Bluetooth address and is refusing the new pairing
 attempt. Clear the speaker's paired-device list (hold the Bluetooth button for
-~10 seconds) so both sides start fresh, then re-pair from the add-on.
+~10 seconds) so both sides start fresh, then re-pair from the app.
 
 **Existing BLE integrations stopped working**: This should not happen by
-design. Check the add-on logs for errors and file an issue on GitHub.
+design. Check the app logs for errors and file an issue on GitHub.

--- a/bluetooth_audio_manager/apparmor.txt
+++ b/bluetooth_audio_manager/apparmor.txt
@@ -8,7 +8,7 @@ profile bluetooth_audio_manager flags=(attach_disconnected,mediate_deleted) {
   capability net_raw,
 
   # S6-overlay and shell — rix needed because /init is a shell script
-  # that /bin/sh must read to interpret (matches dnsmasq, Argon One add-ons)
+  # that /bin/sh must read to interpret (matches dnsmasq, Argon One apps)
   /init rix,
   /bin/** ix,
   /usr/bin/** ix,
@@ -27,7 +27,7 @@ profile bluetooth_audio_manager flags=(attach_disconnected,mediate_deleted) {
   # player and pairing agent using our dynamic unique bus name
   # (:1.xxx), which cannot be allowlisted by peer name.  Broad
   # send/receive on the system bus is the standard pattern for
-  # HA add-ons that interact with BlueZ (cf. dnsmasq, Argon One).
+  # HA apps that interact with BlueZ (cf. dnsmasq, Argon One).
   dbus send    bus=system,
   dbus receive bus=system,
 

--- a/bluetooth_audio_manager/config.yaml
+++ b/bluetooth_audio_manager/config.yaml
@@ -32,7 +32,7 @@ map:
   - type: data
     read_only: false
 
-# User options (runtime settings are managed in the add-on UI)
+# User options (runtime settings are managed in the app UI)
 options:
   log_level: "info"
 

--- a/bluetooth_audio_manager/translations/en.yaml
+++ b/bluetooth_audio_manager/translations/en.yaml
@@ -1,7 +1,7 @@
 configuration:
   log_level:
     name: Log Level
-    description: Logging verbosity for the add-on.
+    description: Logging verbosity for the app.
   auto_reconnect:
     name: Auto Reconnect
     description: Automatically reconnect to paired devices when they become available.

--- a/bluetooth_audio_manager_dev/DOCS.md
+++ b/bluetooth_audio_manager_dev/DOCS.md
@@ -2,8 +2,8 @@
 
 **WARNING: This is a development build and may be unstable.**
 
-This add-on tracks the `dev` branch and is automatically updated with each push.
-For the stable release, use the **Bluetooth Audio Manager** add-on instead.
+This app tracks the `dev` branch and is automatically updated with each push.
+For the stable release, use the **Bluetooth Audio Manager** app instead.
 
 ## Version
 
@@ -13,7 +13,7 @@ For the stable release, use the **Bluetooth Audio Manager** add-on instead.
 This is the latest development build. The version field shows the commit SHA
 of the dev branch build.
 
-> WARNING: This is a development build. For stable releases, use the stable add-on.
+> WARNING: This is a development build. For stable releases, use the stable app.
 <!-- VERSION_INFO_END -->
 
 ## About
@@ -21,5 +21,5 @@ of the dev branch build.
 Development builds of the Bluetooth Audio Manager for testing new features
 and fixes before they are released to the stable channel.
 
-See the [stable add-on documentation](https://github.com/scyto/ha-bluetooth-audio-manager)
+See the [stable app documentation](https://github.com/scyto/ha-bluetooth-audio-manager)
 for full usage instructions.

--- a/bluetooth_audio_manager_dev/apparmor.txt
+++ b/bluetooth_audio_manager_dev/apparmor.txt
@@ -8,7 +8,7 @@ profile bluetooth_audio_manager flags=(attach_disconnected,mediate_deleted) {
   capability net_raw,
 
   # S6-overlay and shell — rix needed because /init is a shell script
-  # that /bin/sh must read to interpret (matches dnsmasq, Argon One add-ons)
+  # that /bin/sh must read to interpret (matches dnsmasq, Argon One apps)
   /init rix,
   /bin/** ix,
   /usr/bin/** ix,
@@ -27,7 +27,7 @@ profile bluetooth_audio_manager flags=(attach_disconnected,mediate_deleted) {
   # player and pairing agent using our dynamic unique bus name
   # (:1.xxx), which cannot be allowlisted by peer name.  Broad
   # send/receive on the system bus is the standard pattern for
-  # HA add-ons that interact with BlueZ (cf. dnsmasq, Argon One).
+  # HA apps that interact with BlueZ (cf. dnsmasq, Argon One).
   dbus send    bus=system,
   dbus receive bus=system,
 

--- a/bluetooth_audio_manager_dev/config.yaml
+++ b/bluetooth_audio_manager_dev/config.yaml
@@ -32,7 +32,7 @@ map:
   - type: data
     read_only: false
 
-# User options (runtime settings are managed in the add-on UI)
+# User options (runtime settings are managed in the app UI)
 options:
   log_level: "info"
 

--- a/src/bt_audio_manager/__init__.py
+++ b/src/bt_audio_manager/__init__.py
@@ -1,3 +1,3 @@
-"""Bluetooth Audio Manager — HAOS add-on for managing Bluetooth audio device connections."""
+"""Bluetooth Audio Manager — HAOS app for managing Bluetooth audio device connections."""
 
 __version__ = "0.1.0"

--- a/src/bt_audio_manager/__main__.py
+++ b/src/bt_audio_manager/__main__.py
@@ -1,4 +1,4 @@
-"""Entry point for the Bluetooth Audio Manager add-on."""
+"""Entry point for the Bluetooth Audio Manager app."""
 
 import asyncio
 import logging

--- a/src/bt_audio_manager/bluez/adapter.py
+++ b/src/bt_audio_manager/bluez/adapter.py
@@ -59,7 +59,7 @@ class BluezAdapter:
         if not powered.value:
             raise AdapterNotPoweredError(
                 "Bluetooth adapter is not powered. "
-                "Enable Bluetooth in HAOS settings — this add-on does not "
+                "Enable Bluetooth in HAOS settings — this app does not "
                 "modify adapter power state."
             )
 

--- a/src/bt_audio_manager/bluez/media_player.py
+++ b/src/bt_audio_manager/bluez/media_player.py
@@ -5,7 +5,7 @@ commands, BlueZ forwards them as D-Bus method calls to a registered MPRIS
 player.  This module exports that player and registers it with BlueZ via
 org.bluez.Media1.RegisterPlayer().
 
-The speaker buttons then appear as events in the add-on's UI.
+The speaker buttons then appear as events in the app's UI.
 """
 
 import logging

--- a/src/bt_audio_manager/config.py
+++ b/src/bt_audio_manager/config.py
@@ -1,11 +1,11 @@
-"""Configuration loader for the Bluetooth Audio Manager add-on.
+"""Configuration loader for the Bluetooth Audio Manager app.
 
 Reads user options from /data/options.json which is injected by
 the HA Supervisor based on the schema defined in config.yaml.
 
 Runtime settings (auto_reconnect, reconnect intervals, scan duration,
 bt_adapter) are stored in /data/settings.json and managed via the
-add-on's web UI.
+app's web UI.
 """
 
 import json
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 OPTIONS_PATH = "/data/options.json"
 SETTINGS_PATH = "/data/settings.json"
 
-# Keys that live in settings.json (managed via add-on UI)
+# Keys that live in settings.json (managed via app UI)
 _SETTINGS_KEYS = {
     "bt_adapter",
     "auto_reconnect",
@@ -30,12 +30,12 @@ _SETTINGS_KEYS = {
 
 @dataclass
 class AppConfig:
-    """Application configuration loaded from HA add-on options + settings."""
+    """Application configuration loaded from HA app options + settings."""
 
     # From options.json (HAOS config page — requires restart)
     log_level: str = "info"
 
-    # From settings.json (add-on UI)
+    # From settings.json (app UI)
     bt_adapter: str = "auto"
     auto_reconnect: bool = True
     reconnect_interval_seconds: int = 30

--- a/src/bt_audio_manager/manager.py
+++ b/src/bt_audio_manager/manager.py
@@ -47,7 +47,7 @@ _USB_BT_VENDORS: dict[str, str] = {
 
 
 class BluetoothAudioManager:
-    """Central orchestrator for the Bluetooth Audio Manager add-on."""
+    """Central orchestrator for the Bluetooth Audio Manager app."""
 
     SINK_POLL_INTERVAL = 5  # seconds between sink state polls
     MAX_RECENT_EVENTS = 50  # ring buffer size for MPRIS/AVRCP events
@@ -187,7 +187,7 @@ class BluetoothAudioManager:
 
                     # Silently discard noisy RSSI / ManufacturerData / TxPower
                     # churn — these fire many times per second per device and
-                    # provide no actionable information for this add-on.
+                    # provide no actionable information for this app.
                     _NOISY_PROPS = {"RSSI", "ManufacturerData", "TxPower"}
                     if iface_name == "org.bluez.Device1" and set(prop_names) <= _NOISY_PROPS:
                         pass
@@ -287,7 +287,7 @@ class BluetoothAudioManager:
 
         # 6. Register BluezDevice objects for all stored devices so UI
         #    actions (disconnect, forget) work immediately, even if the
-        #    device is already connected from a previous add-on session.
+        #    device is already connected from a previous app session.
         for device_info in self.store.devices:
             addr = device_info["address"]
             try:
@@ -349,7 +349,7 @@ class BluetoothAudioManager:
 
         # 6b. Detect devices connected at the BlueZ level but NOT in our
         #     store (e.g. store wiped during rebuild, or device paired outside
-        #     the add-on).  Create BluezDevice wrappers so UI buttons work.
+        #     the app).  Create BluezDevice wrappers so UI buttons work.
         try:
             from .bluez.constants import BLUEZ_SERVICE, OBJECT_MANAGER_INTERFACE, DEVICE_INTERFACE
             intro = await self.bus.introspect(BLUEZ_SERVICE, "/")
@@ -475,7 +475,7 @@ class BluetoothAudioManager:
             await self.pulse.disconnect()
 
         # Disconnect D-Bus (do NOT disconnect BT devices — user may want
-        # audio to persist if the add-on restarts)
+        # audio to persist if the app restarts)
         if self.bus:
             self.bus.disconnect()
 
@@ -795,7 +795,7 @@ class BluetoothAudioManager:
             device.cleanup()
 
         # Remove from BlueZ (search all adapters — device may be on a
-        # different adapter than the one this add-on is configured to use)
+        # different adapter than the one this app is configured to use)
         await BluezAdapter.remove_device_any_adapter(self.bus, address)
 
         # Remove from persistent store
@@ -924,7 +924,7 @@ class BluetoothAudioManager:
         """List all Bluetooth adapters on the system.
 
         Each adapter dict includes a flag indicating whether it's the
-        one this add-on is configured to use, and whether it appears to
+        one this app is configured to use, and whether it appears to
         be running HA's BLE scanning (Discovering=true).
 
         Enriches adapter entries with USB device names from the HA
@@ -1254,7 +1254,7 @@ class BluetoothAudioManager:
     async def _refresh_avrcp_session(self, address: str) -> None:
         """Cycle AVRCP profiles to rebind the control channel to this process.
 
-        After an add-on restart the old D-Bus unique name is gone, but the
+        After an app restart the old D-Bus unique name is gone, but the
         AVRCP session still references it.  Disconnecting and reconnecting
         the AVRCP profiles forces BlueZ to re-discover our newly registered
         MPRIS player without tearing down the A2DP audio stream.

--- a/src/bt_audio_manager/persistence/store.py
+++ b/src/bt_audio_manager/persistence/store.py
@@ -1,7 +1,7 @@
 """JSON-backed persistent store for paired device information.
 
 Data is stored in /data/paired_devices.json which persists across
-container restarts, add-on updates, and is included in HA backups.
+container restarts, app updates, and is included in HA backups.
 """
 
 import json

--- a/src/bt_audio_manager/reconnect.py
+++ b/src/bt_audio_manager/reconnect.py
@@ -85,7 +85,7 @@ class ReconnectService:
 
     async def _reconnect_loop(self, address: str) -> None:
         """Attempt reconnection with exponential backoff and jitter."""
-        # Check if already connected (e.g. device persisted across add-on restart)
+        # Check if already connected (e.g. device persisted across app restart)
         device = self._manager.managed_devices.get(address)
         if device:
             try:

--- a/src/bt_audio_manager/web/api.py
+++ b/src/bt_audio_manager/web/api.py
@@ -69,7 +69,7 @@ def create_api_routes(
 
     @routes.get("/api/info")
     async def info(request: web.Request) -> web.Response:
-        """Return add-on version and adapter info for the UI."""
+        """Return app version and adapter info for the UI."""
         import os
         path = manager._adapter_path or "/org/bluez/hci0"
         adapter_name = path.rsplit("/", 1)[-1]
@@ -129,7 +129,7 @@ def create_api_routes(
 
     @routes.post("/api/restart")
     async def restart_addon(request: web.Request) -> web.Response:
-        """Restart this add-on via the HA Supervisor API."""
+        """Restart this app via the HA Supervisor API."""
         import aiohttp
         try:
             supervisor_token = os.environ.get("SUPERVISOR_TOKEN")
@@ -152,7 +152,7 @@ def create_api_routes(
 
             return web.json_response({"restarting": True})
         except Exception as e:
-            logger.error("Failed to restart add-on: %s", e)
+            logger.error("Failed to restart app: %s", e)
             return web.json_response({"error": str(e)}, status=500)
 
     @routes.get("/api/devices")

--- a/src/bt_audio_manager/web/server.py
+++ b/src/bt_audio_manager/web/server.py
@@ -1,4 +1,4 @@
-"""aiohttp web server for the add-on's ingress UI and REST API.
+"""aiohttp web server for the app's ingress UI and REST API.
 
 NOTE: Static assets are served from /res/ (not /static/) to avoid
 HA's frontend service worker, which applies a CacheFirst strategy

--- a/src/bt_audio_manager/web/static/app.js
+++ b/src/bt_audio_manager/web/static/app.js
@@ -2,7 +2,7 @@
  * Bluetooth Audio Manager — Ingress UI
  *
  * Vanilla JS interface with Bootstrap 5.3 components.
- * Communicates with the add-on's REST API via WebSocket for real-time updates.
+ * Communicates with the app's REST API via WebSocket for real-time updates.
  */
 
 // ============================================
@@ -848,7 +848,7 @@ async function doAdapterSwitch(adapterMac, displayLabel, clean) {
       clean: clean,
     });
     if (result.restart_required) {
-      showBanner("Restarting add-on with new adapter...");
+      showBanner("Restarting app with new adapter...");
       // Fire-and-forget: the server will die during restart, so the
       // response will never arrive (expected 502). The WebSocket
       // reconnect loop will detect when the server is back.
@@ -897,7 +897,7 @@ async function saveDeviceSettings() {
 }
 
 // ============================================
-// Section 11c: Add-on Settings Modal
+// Section 11c: App Settings Modal
 // ============================================
 
 async function openSettingsModal() {

--- a/src/bt_audio_manager/web/static/index.html
+++ b/src/bt_audio_manager/web/static/index.html
@@ -51,7 +51,7 @@
             </button>
             <ul class="dropdown-menu dropdown-menu-end">
               <li><a class="dropdown-item" href="#" onclick="openSettingsModal(); return false;">
-                <i class="fas fa-sliders me-2"></i>Add-on Settings
+                <i class="fas fa-sliders me-2"></i>App Settings
               </a></li>
               <li><a class="dropdown-item" href="#" onclick="openAdaptersModal(); return false;">
                 <i class="fas fa-microchip me-2"></i>Bluetooth Adapters
@@ -189,10 +189,10 @@
             <i class="fas fa-exclamation-triangle me-2"></i>
             <strong>Recommendation:</strong> Use a dedicated Bluetooth adapter that is
             <strong>not configured in Home Assistant</strong> and is not used for BLE scanning.
-            Leave the adapter unconfigured in HA &mdash; this add-on will manage it directly.
+            Leave the adapter unconfigured in HA &mdash; this app will manage it directly.
           </div>
           <p class="text-muted">
-            Only one adapter can be active at a time. Select which Bluetooth adapter to use. Changing the adapter requires an add-on restart.
+            Only one adapter can be active at a time. Select which Bluetooth adapter to use. Changing the adapter requires an app restart.
           </p>
           <div id="adapters-container">
             <div class="text-center py-4">
@@ -229,7 +229,7 @@
             to be re-paired on the new adapter.
           </div>
           <p class="mb-0 text-muted small">
-            All connected devices will be disconnected and removed before the add-on restarts
+            All connected devices will be disconnected and removed before the app restarts
             with the new adapter.
           </p>
         </div>
@@ -243,12 +243,12 @@
     </div>
   </div>
 
-  <!-- ========== ADD-ON SETTINGS MODAL ========== -->
+  <!-- ========== APP SETTINGS MODAL ========== -->
   <div class="modal fade" id="settingsModal" tabindex="-1">
     <div class="modal-dialog modal-dialog-centered">
       <div class="modal-content">
         <div class="modal-header">
-          <h5 class="modal-title"><i class="fas fa-sliders me-2"></i>Add-on Settings</h5>
+          <h5 class="modal-title"><i class="fas fa-sliders me-2"></i>App Settings</h5>
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
         </div>
         <div class="modal-body">


### PR DESCRIPTION
## Summary
- Renames all user-facing "add-on" references to "app" across 22 files to align with [Home Assistant 2026.2 terminology](https://www.home-assistant.io/blog/2026/02/04/release-20262)
- Updates docs, UI labels, config comments, translations, docstrings, GitHub issue templates, and workflow display names
- Preserves all technical identifiers per the [architecture proposal](https://github.com/home-assistant/architecture/discussions/1287): Docker label `io.hass.type="addon"`, Supervisor API URL `/addons/self/restart`, Python function `restart_addon`, workflow job IDs

## Test plan
- [ ] Verify web UI shows "App Settings" in the settings dropdown and modal title
- [ ] Verify adapter modal text says "this app will manage it directly" and "requires an app restart"
- [ ] Verify adapter switch confirmation says "before the app restarts"
- [ ] Verify `io.hass.type="addon"` Docker label is unchanged (build succeeds)
- [ ] Verify `/api/restart` still calls `/addons/self/restart` Supervisor API

🤖 Generated with [Claude Code](https://claude.com/claude-code)