### PR TITLE
Replace native confirm() with Bootstrap modal

### DIFF
--- a/src/bt_audio_manager/web/static/app.js
+++ b/src/bt_audio_manager/web/static/app.js
@@ -802,8 +802,19 @@ async function forceReconnectDevice(address) {
   }
 }
 
-async function forgetDevice(address) {
-  if (!confirm(`Forget device ${address}? This will unpair it.`)) return;
+let _pendingForgetAddress = null;
+
+function forgetDevice(address) {
+  _pendingForgetAddress = address;
+  $("#forget-device-address").textContent = address;
+  new bootstrap.Modal("#forgetDeviceModal").show();
+}
+
+async function doForgetDevice() {
+  if (!_pendingForgetAddress) return;
+  const address = _pendingForgetAddress;
+  _pendingForgetAddress = null;
+  bootstrap.Modal.getInstance($("#forgetDeviceModal"))?.hide();
   try {
     await apiPost("/api/forget", { address });
   } catch (e) {
@@ -1061,6 +1072,12 @@ document.addEventListener("DOMContentLoaded", () => {
   // Wire up keep-alive toggle in device settings modal
   const kaToggle = $("#setting-keep-alive-enabled");
   if (kaToggle) kaToggle.addEventListener("change", toggleKeepAliveMethodVisibility);
+
+  // Wire up forget-device confirmation button
+  const confirmForgetBtn = $("#btn-confirm-forget");
+  if (confirmForgetBtn) {
+    confirmForgetBtn.addEventListener("click", () => doForgetDevice());
+  }
 
   // Wire up adapter-switch confirmation button
   const confirmSwitchBtn = $("#btn-confirm-adapter-switch");

--- a/src/bt_audio_manager/web/static/index.html
+++ b/src/bt_audio_manager/web/static/index.html
@@ -349,6 +349,29 @@
     </div>
   </div>
 
+  <!-- ========== FORGET DEVICE CONFIRMATION MODAL ========== -->
+  <div class="modal fade" id="forgetDeviceModal" tabindex="-1">
+    <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-content">
+        <div class="modal-header bg-danger-subtle">
+          <h5 class="modal-title">
+            <i class="fas fa-exclamation-triangle text-danger me-2"></i>Forget Device
+          </h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <p>Forget device <strong id="forget-device-address"></strong>? This will unpair it.</p>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+          <button type="button" class="btn btn-danger" id="btn-confirm-forget">
+            <i class="fas fa-trash me-1"></i>Forget
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <!-- Footer -->
   <footer class="app-footer text-center py-2 text-muted">
     <span id="version-label"></span>


### PR DESCRIPTION
## Summary
- Replaced the browser-native `confirm()` dialog in `forgetDevice()` with a Bootstrap 5 confirmation modal
- New `#forgetDeviceModal` follows the same pattern as the existing adapter switch confirmation modal
- Danger-styled header and button to clearly communicate the destructive action

## Test plan
- [ ] Click "Forget Device" on a paired device and verify the Bootstrap modal appears
- [ ] Click "Cancel" and verify the device is not removed
- [ ] Click "Forget" and verify the device is unpaired and removed
- [ ] Verify no browser-native `confirm()` dialogs remain in the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)