### PR TITLE
Fix silent TTS, MPD database perms, and toggle persistence

### DIFF
--- a/bluetooth_audio_manager/apparmor.txt
+++ b/bluetooth_audio_manager/apparmor.txt
@@ -66,6 +66,9 @@ profile bluetooth_audio_manager flags=(attach_disconnected,mediate_deleted) {
   # Shared data (ICU unicode data required by MPD, MIME types)
   /usr/share/** r,
 
+  # SSL certificates (MPD curl plugin needs these for HTTPS TTS URLs)
+  /etc/ssl/** r,
+
   # DNS resolution (required for Supervisor API calls via hostname)
   /etc/resolv.conf r,
   /etc/nsswitch.conf r,

--- a/bluetooth_audio_manager_dev/apparmor.txt
+++ b/bluetooth_audio_manager_dev/apparmor.txt
@@ -66,6 +66,9 @@ profile bluetooth_audio_manager flags=(attach_disconnected,mediate_deleted) {
   # Shared data (ICU unicode data required by MPD, MIME types)
   /usr/share/** r,
 
+  # SSL certificates (MPD curl plugin needs these for HTTPS TTS URLs)
+  /etc/ssl/** r,
+
   # DNS resolution (required for Supervisor API calls via hostname)
   /etc/resolv.conf r,
   /etc/nsswitch.conf r,

--- a/src/bt_audio_manager/audio/mpd.py
+++ b/src/bt_audio_manager/audio/mpd.py
@@ -102,6 +102,7 @@ class MPDManager:
             port                "{port}"
             log_level           "verbose"
             auto_update         "no"
+            user                "root"
 
             audio_output {{
                 type    "pulse"

--- a/src/bt_audio_manager/manager.py
+++ b/src/bt_audio_manager/manager.py
@@ -898,6 +898,7 @@ class BluetoothAudioManager:
                 device["keep_alive_enabled"] = s["keep_alive_enabled"]
                 device["keep_alive_method"] = s["keep_alive_method"]
                 device["keep_alive_active"] = addr in self._keepalives
+                device["mpd_enabled"] = s.get("mpd_enabled", False)
 
         # Add stored devices not currently visible
         discovered_addresses = {d["address"] for d in discovered}
@@ -920,6 +921,7 @@ class BluetoothAudioManager:
                         "keep_alive_enabled": s["keep_alive_enabled"],
                         "keep_alive_method": s["keep_alive_method"],
                         "keep_alive_active": addr in self._keepalives,
+                        "mpd_enabled": s.get("mpd_enabled", False),
                     }
                 )
 


### PR DESCRIPTION
## Summary
Three bugs found during live testing:

1. **Silent TTS playback** — MPD's curl plugin couldn't read SSL certificates (`/etc/ssl/cert.pem`) because AppArmor blocked access. TTS URLs are HTTPS, so fetches silently failed. Added `/etc/ssl/** r` to both AppArmor profiles.

2. **MPD database "Permission denied"** — MPD drops privileges from root to `mpd` user by default. Added `user "root"` to the generated mpd.conf since we're in a container.

3. **MPD toggle resets in UI** — `get_all_devices()` included `keep_alive_enabled` but not `mpd_enabled` in the device data sent to the frontend. The toggle appeared to save but reverted on refresh.

## Test plan
- [ ] TTS plays audio through BT speaker (no more CURL SSL error in logs)
- [ ] No "Permission denied" for `/data/mpd/database` in logs
- [ ] MPD toggle stays checked after saving and refreshing

🤖 Generated with [Claude Code](https://claude.com/claude-code)