### PR TITLE
Fix MPD user privilege drop on Alpine

### DIFF
--- a/docker/rootfs/etc/cont-init.d/03-init-mpd.sh
+++ b/docker/rootfs/etc/cont-init.d/03-init-mpd.sh
@@ -5,5 +5,6 @@
 # ==============================================================================
 
 mkdir -p /data/mpd/music /data/mpd/playlists
+chown -R mpd:mpd /data/mpd
 
 bashio::log.info "MPD directories initialized."


### PR DESCRIPTION
## Summary
- Removed `user "root"` from generated mpd.conf — Alpine's minimal container doesn't have a root entry MPD can resolve, causing `no such user "root"` at startup
- Added `_chown_mpd_dirs()` to recursively chown `/data/mpd/` to the `mpd` user/group before starting the daemon, so MPD can write its database after dropping privileges
- Updated `03-init-mpd.sh` to also `chown -R mpd:mpd /data/mpd` at container init

## Test plan
- [ ] Enable MPD on a connected device — daemon should start without "no such user" error
- [ ] MPD should be able to write its database file (`/data/mpd/database`)
- [ ] TTS playback through HA MPD integration should produce audio

🤖 Generated with [Claude Code](https://claude.com/claude-code)