### PR TITLE
Add HA Bluetooth managed badge and always show BLE scanning

### DIFF
--- a/bluetooth_audio_manager/config.yaml
+++ b/bluetooth_audio_manager/config.yaml
@@ -16,6 +16,7 @@ boot: auto
 # Permissions (least privilege)
 host_dbus: true
 hassio_api: true
+homeassistant_api: true
 audio: true
 privileged:
   - NET_ADMIN

--- a/bluetooth_audio_manager_dev/config.yaml
+++ b/bluetooth_audio_manager_dev/config.yaml
@@ -16,6 +16,7 @@ boot: auto
 # Permissions (least privilege)
 host_dbus: true
 hassio_api: true
+homeassistant_api: true
 audio: true
 privileged:
   - NET_ADMIN

--- a/src/bt_audio_manager/web/static/app.js
+++ b/src/bt_audio_manager/web/static/app.js
@@ -465,6 +465,9 @@ function renderAdaptersModal(adapters) {
       const bleBadge = a.ble_scanning
         ? '<span class="badge bg-warning ms-2">HA BLE Scanning</span>'
         : "";
+      const haManagedBadge = a.ha_managed
+        ? '<span class="badge bg-info ms-2">HA Bluetooth</span>'
+        : "";
       const poweredBadge = a.powered
         ? '<span class="badge bg-success">Powered</span>'
         : '<span class="badge bg-secondary">Off</span>';
@@ -497,7 +500,7 @@ function renderAdaptersModal(adapters) {
               <div class="font-monospace small text-muted">${escapeHtml(a.address)}</div>
             </div>
             <div class="d-flex align-items-center gap-2">
-              ${poweredBadge}${selectedBadge}${bleBadge}
+              ${poweredBadge}${selectedBadge}${haManagedBadge}${bleBadge}
               ${selectBtn}
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Query HA Core's config entries API to detect adapters configured in HA's Bluetooth integration, showing an **"HA Bluetooth"** badge (blue) on managed adapters
- Always show the **"HA BLE Scanning"** badge when an adapter has `Discovering=true`, including the selected adapter (previously excluded)
- Add `homeassistant_api: true` permission to both add-on configs for HA Core API access

## Test plan
- [ ] Deploy to HA with at least one adapter in HA's Bluetooth integration — verify "HA Bluetooth" badge appears
- [ ] Verify "HA BLE Scanning" badge appears on the selected adapter when HA is scanning on it
- [ ] Test with no Bluetooth integration configured — no "HA Bluetooth" badges
- [ ] Test outside HA (no Supervisor) — graceful degradation, no badges, no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)