### PR TITLE
Multi-instance MPD: one daemon per BT speaker

### DIFF
--- a/bluetooth_audio_manager/config.yaml
+++ b/bluetooth_audio_manager/config.yaml
@@ -28,12 +28,6 @@ ingress_port: 8099
 panel_icon: "mdi:bluetooth-audio"
 panel_title: "BT Audio"
 
-# MPD media player (port exposed for HA's MPD integration)
-ports:
-  "6600/tcp": 6600
-ports_description:
-  "6600/tcp": "MPD server for HA MPD integration"
-
 # Storage
 map:
   - type: data
@@ -42,9 +36,11 @@ map:
 # User options (runtime settings are managed in the app UI)
 options:
   log_level: "info"
+  mpd_password: ""
 
 schema:
   log_level: "list(debug|info|warning|error)"
+  mpd_password: "str?"
 
 apparmor: true
 watchdog: "http://[HOST]:[PORT:8099]/api/health"

--- a/bluetooth_audio_manager_dev/config.yaml
+++ b/bluetooth_audio_manager_dev/config.yaml
@@ -36,9 +36,11 @@ map:
 # User options (runtime settings are managed in the app UI)
 options:
   log_level: "info"
+  mpd_password: ""
 
 schema:
   log_level: "list(debug|info|warning|error)"
+  mpd_password: "str?"
 
 apparmor: true
 watchdog: "http://[HOST]:[PORT:8099]/api/health"

--- a/src/bt_audio_manager/web/static/index.html
+++ b/src/bt_audio_manager/web/static/index.html
@@ -344,7 +344,8 @@
           <!-- MPD Media Player Toggle -->
           <div class="mb-3">
             <div class="form-check form-switch">
-              <input class="form-check-input" type="checkbox" id="setting-mpd-enabled">
+              <input class="form-check-input" type="checkbox" id="setting-mpd-enabled"
+                     onchange="toggleMpdConfigVisibility()">
               <label class="form-check-label" for="setting-mpd-enabled">
                 <strong>MPD Media Player</strong>
               </label>
@@ -353,6 +354,31 @@
               Route MPD audio output to this speaker. Add the
               <a href="https://www.home-assistant.io/integrations/mpd/" target="_blank" rel="noopener">HA MPD integration</a>
               to create a <code>media_player</code> entity for TTS and media playback.
+            </div>
+          </div>
+
+          <!-- MPD Config (shown when enabled) -->
+          <div id="mpd-config-group" style="display:none;">
+            <div class="mb-3">
+              <label for="setting-mpd-name" class="form-label">MPD Name</label>
+              <input type="text" class="form-control" id="setting-mpd-name"
+                     placeholder="(defaults to speaker name)" maxlength="64">
+              <div class="form-text">
+                Name shown in MPD clients and HA. Leave blank to use the Bluetooth device name.
+              </div>
+            </div>
+            <div class="mb-3">
+              <label for="setting-mpd-port" class="form-label">MPD Port</label>
+              <input type="number" class="form-control" id="setting-mpd-port"
+                     min="6600" max="6609" step="1">
+              <div class="form-text">
+                Port for this speaker's MPD instance (6600–6609). Auto-assigned on first enable.
+              </div>
+            </div>
+            <div class="alert alert-info py-2 mb-0" id="mpd-connection-info">
+              <i class="fas fa-info-circle me-1"></i>
+              Use port <strong id="mpd-port-display"></strong> when adding the HA MPD integration.<br>
+              <span class="form-text">Host: <code id="mpd-hostname"></code></span>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Converts from a single shared MPD daemon to **per-device instances** (up to 10, ports 6600-6609)
- Each speaker gets its own MPD config, database, state files, and PulseAudio sink target
- **Port auto-assigned** from pool on first enable; user can override in settings modal
- **Per-device MPD name** (defaults to BT device name, user can customize)
- **Global `mpd_password`** option in add-on config (shared across all instances)
- **AVRCP routing**: button presses route to the correct MPD instance via `_last_avrcp_device` tracking from BlueZ MediaPlayer1 events — never broadcasts to all instances
- MPRIS WebSocket events now include the resolved device address for accurate UI display
- Static port mapping removed from config.yaml (HA connects via Docker network)
- Settings modal shows port, name fields, and connection info when MPD is enabled

## Files changed (8)
- `persistence/store.py` — port allocation pool (`allocate_mpd_port`, `set_mpd_port`, `release_mpd_port`), `mpd_port` + `mpd_name` in DEFAULT_DEVICE_SETTINGS
- `audio/mpd.py` — parameterized MPDManager (address, port, speaker_name, password), per-instance paths
- `manager.py` — `_mpd_instances` dict, AVRCP routing, password reading, lifecycle management
- `web/api.py` — `mpd_port` + `mpd_name` validation (port range, conflict detection, name length)
- `web/static/index.html` — MPD name/port fields + connection info in settings modal
- `web/static/app.js` — populate/save MPD settings, improved MPRIS event display
- Both `config.yaml` — add `mpd_password` option, remove static port mapping

## Test plan
- [ ] Enable MPD on device A — gets port 6600, shown in settings modal
- [ ] Enable MPD on device B — gets port 6601, both visible
- [ ] Add two HA MPD integrations (different ports) — two media_player entities
- [ ] TTS playback on each entity routes to correct speaker
- [ ] AVRCP: press pause on speaker A — only MPD A pauses
- [ ] Custom port: change port in settings — MPD restarts on new port
- [ ] Port conflict: assign same port as another device — 409 error
- [ ] Custom name: set name — visible in MPD output name
- [ ] Password: set in add-on config — MPD requires auth
- [ ] Disable MPD — daemon stops, port released
- [ ] Disconnect/reconnect — same port, MPD auto-restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)