### PR TITLE
Fix MPD settings save bugs

### DIFF
--- a/src/bt_audio_manager/web/static/app.js
+++ b/src/bt_audio_manager/web/static/app.js
@@ -967,8 +967,13 @@ async function saveDeviceSettings() {
     if (portVal) settings.mpd_port = parseInt(portVal, 10);
   }
   try {
-    await apiPut(`/api/devices/${encodeURIComponent(_settingsAddress)}/settings`, settings);
-    showToast("Device settings saved", "success");
+    const resp = await apiPut(`/api/devices/${encodeURIComponent(_settingsAddress)}/settings`, settings);
+    const port = resp.settings?.mpd_port;
+    if (settings.mpd_enabled && port) {
+      showToast(`Settings saved — MPD on port ${port}`, "success");
+    } else {
+      showToast("Device settings saved", "success");
+    }
     bootstrap.Modal.getInstance($("#deviceSettingsModal"))?.hide();
   } catch (e) {
     showToast(`Failed to save settings: ${e.message}`, "error");


### PR DESCRIPTION
## Summary
- **Auto-store paired devices**: If a device is paired via BlueZ but not yet in the add-on's persistence store (edge case after migration or manual pairing), auto-add it when saving settings instead of returning "Device not found"
- **Fix misleading port conflict error**: `set_mpd_port` returning `False` for "device not found" was reported as "port already in use" (409). Now checks device existence separately first
- **Return allocated port in response**: Save response now includes the actual stored settings (with auto-allocated port), and the UI shows the port number in the success toast: "Settings saved — MPD on port 6600"

## Test plan
- [ ] Enable MPD on a connected device — toast should show "Settings saved — MPD on port 6600"
- [ ] Re-open settings — port field should show the allocated port
- [ ] Try setting a port already used by another device — should get clear "port in use" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)