### PR TITLE
Fix AVRCP commands not routing to MPD

### DIFF
--- a/src/bt_audio_manager/manager.py
+++ b/src/bt_audio_manager/manager.py
@@ -1811,8 +1811,16 @@ class BluetoothAudioManager:
             mpd = self._mpd_instances.get(target_addr)
             if mpd and mpd.is_running:
                 asyncio.ensure_future(mpd.handle_command(command, detail))
+        elif len(self._mpd_instances) == 1:
+            # Single MPD instance — no disambiguation needed
+            mpd = next(iter(self._mpd_instances.values()))
+            if mpd.is_running:
+                asyncio.ensure_future(mpd.handle_command(command, detail))
         else:
-            logger.debug("Cannot determine source device for MPRIS command %s, ignoring", command)
+            logger.warning(
+                "Multiple MPD instances but cannot determine source device for MPRIS %s — ignoring",
+                command,
+            )
 
     def _on_avrcp_event(self, address: str, prop_name: str, value: object) -> None:
         """Handle AVRCP MediaPlayer1 property change — push to WebSocket."""


### PR DESCRIPTION
## Summary
- Most BT speakers don't create a BlueZ MediaPlayer1 node, so `_on_avrcp_event("Status")` never fires and `_last_avrcp_device` stays `None`
- With the strict routing from PR #67, this meant ALL button presses (play/pause/next/prev/volume) were silently dropped — the debug log said "Cannot determine source device" and ignored the command
- Fix: when exactly one MPD instance is running, route directly — no disambiguation needed
- With multiple instances, still require `_last_avrcp_device` tracking; upgraded log from debug to warning so the user can see it

## Test plan
- [ ] Press pause on speaker during TTS/media playback — MPD should pause, HA entity should update
- [ ] Press play — playback should resume
- [ ] Volume buttons — MPD volume should change

🤖 Generated with [Claude Code](https://claude.com/claude-code)