### PR TITLE
Eagerly allocate MPD port when enabling

### DIFF
--- a/src/bt_audio_manager/manager.py
+++ b/src/bt_audio_manager/manager.py
@@ -1991,5 +1991,11 @@ class BluetoothAudioManager:
                     await self._stop_mpd(address)
                     await self.store.release_mpd_port(address)
 
+        # Eagerly allocate a port when MPD is enabled so the UI shows it
+        # immediately (even if the device isn't connected yet / no PA sink)
+        if "mpd_enabled" in settings and device_info.get("mpd_enabled", False):
+            if self.store.get_device_settings(address).get("mpd_port") is None:
+                await self.store.allocate_mpd_port(address)
+
         await self._broadcast_devices()
         return device_info


### PR DESCRIPTION
## Summary
- Allocate an MPD port immediately when the user enables MPD in settings, rather than deferring to `_start_mpd_if_enabled` (which requires device connected + PA sink ready)
- The port field in the UI now shows the allocated port right away

## Problem
Port allocation only happened inside `_start_mpd_if_enabled`, which requires:
1. Device to be connected (`address in self._device_connect_time`)
2. PulseAudio to be available
3. A PA sink to exist for the device

If any condition wasn't met, the port was never allocated and the UI showed an empty port field. Users couldn't configure HA's MPD integration without knowing the port.

## Test plan
- [ ] Pair a new device, enable MPD in settings
- [ ] Port field should show the allocated port (e.g. 6600) immediately after save
- [ ] Reopen settings — port should still be visible
- [ ] MPD should still start correctly when device connects

🤖 Generated with [Claude Code](https://claude.com/claude-code)