### PR TITLE
Replace MPD name with configurable hardware volume

### DIFF
--- a/src/bt_audio_manager/manager.py
+++ b/src/bt_audio_manager/manager.py
@@ -907,7 +907,7 @@ class BluetoothAudioManager:
                 device["keep_alive_active"] = addr in self._keepalives
                 device["mpd_enabled"] = s.get("mpd_enabled", False)
                 device["mpd_port"] = s.get("mpd_port")
-                device["mpd_name"] = s.get("mpd_name", "")
+                device["mpd_hw_volume"] = s.get("mpd_hw_volume", 100)
 
         # Add stored devices not currently visible
         discovered_addresses = {d["address"] for d in discovered}
@@ -932,7 +932,7 @@ class BluetoothAudioManager:
                         "keep_alive_active": addr in self._keepalives,
                         "mpd_enabled": s.get("mpd_enabled", False),
                         "mpd_port": s.get("mpd_port"),
-                        "mpd_name": s.get("mpd_name", ""),
+                        "mpd_hw_volume": s.get("mpd_hw_volume", 100),
                     }
                 )
 
@@ -1951,11 +1951,12 @@ class BluetoothAudioManager:
             logger.warning("Cannot start MPD for %s: all 10 ports in use", address)
             return
 
-        # Determine the MPD instance name
-        mpd_name = settings.get("mpd_name", "")
-        if not mpd_name:
-            device_info = self.store.get_device(address)
-            mpd_name = device_info["name"] if device_info else address
+        # Auto-generate MPD name from device name + last 5 chars of MAC
+        # for disambiguation when multiple devices share the same name
+        device_info = self.store.get_device(address)
+        device_name = device_info["name"] if device_info else address
+        mac_suffix = address.replace(":", "")[-5:].upper()
+        mpd_name = f"{device_name} ({mac_suffix})"
 
         mpd_password = self._get_mpd_password()
 
@@ -1980,7 +1981,7 @@ class BluetoothAudioManager:
     async def _init_mpd_volume(
         self, address: str, mpd: "MPDManager", sink_name: str
     ) -> None:
-        """Set hardware volume to 100% and MPD to 100% when no stream is active.
+        """Set hardware volume to configured level when no stream is active.
 
         Makes MPD the single volume control — HA automations can then
         reliably set volume via ``media_player.volume_set`` before TTS.
@@ -1990,16 +1991,18 @@ class BluetoothAudioManager:
         if not self.pulse:
             return
         try:
+            settings = self.store.get_device_settings(address)
+            hw_vol = settings.get("mpd_hw_volume", 100)
             vol_state = await self.pulse.get_sink_volume(sink_name)
             if not vol_state:
                 return
             current_vol, state = vol_state
             if state != "running":
-                # No active stream — safe to reset hardware to 100%
-                await self.pulse.set_sink_volume(sink_name, 100)
+                # No active stream — safe to set hardware to configured level
+                await self.pulse.set_sink_volume(sink_name, hw_vol)
                 logger.info(
-                    "Hardware volume set to 100%% for %s (was %d%%, state=%s)",
-                    address, current_vol, state,
+                    "Hardware volume set to %d%% for %s (was %d%%, state=%s)",
+                    hw_vol, address, current_vol, state,
                 )
             else:
                 # Stream active — sync MPD to current hardware volume
@@ -2035,7 +2038,7 @@ class BluetoothAudioManager:
 
         # React to MPD changes if device is connected
         if address in self._device_connect_time:
-            mpd_changed = {"mpd_enabled", "mpd_port", "mpd_name"}.intersection(settings)
+            mpd_changed = {"mpd_enabled", "mpd_port", "mpd_hw_volume"}.intersection(settings)
             if mpd_changed:
                 if device_info.get("mpd_enabled", False):
                     # Restart to pick up any config changes (port, name)

--- a/src/bt_audio_manager/persistence/store.py
+++ b/src/bt_audio_manager/persistence/store.py
@@ -20,7 +20,7 @@ DEFAULT_DEVICE_SETTINGS = {
     "keep_alive_method": "infrasound",
     "mpd_enabled": False,
     "mpd_port": None,   # Auto-assigned from pool (6600-6609); user can override
-    "mpd_name": "",      # Custom MPD name; empty = use BT device name
+    "mpd_hw_volume": 100,  # Hardware volume % set when MPD starts (1-100)
 }
 
 MPD_PORT_MIN = 6600
@@ -168,7 +168,6 @@ class PersistenceStore:
             return
         old_port = device.get("mpd_port")
         device["mpd_port"] = None
-        device["mpd_name"] = ""
         await self.save()
         if old_port is not None:
             logger.info("Released MPD port %d for %s", old_port, address)

--- a/src/bt_audio_manager/web/api.py
+++ b/src/bt_audio_manager/web/api.py
@@ -294,7 +294,7 @@ def create_api_routes(
             body = await request.json()
             allowed_keys = {
                 "keep_alive_enabled", "keep_alive_method",
-                "mpd_enabled", "mpd_port", "mpd_name",
+                "mpd_enabled", "mpd_port", "mpd_hw_volume",
             }
             settings = {k: v for k, v in body.items() if k in allowed_keys}
             if not settings:
@@ -330,10 +330,11 @@ def create_api_routes(
                         status=409,
                     )
                 await manager.store.set_mpd_port(address, port)
-            if "mpd_name" in settings:
-                if not isinstance(settings["mpd_name"], str) or len(settings["mpd_name"]) > 64:
+            if "mpd_hw_volume" in settings:
+                v = settings["mpd_hw_volume"]
+                if not isinstance(v, int) or v < 1 or v > 100:
                     return web.json_response(
-                        {"error": "mpd_name must be a string (max 64 chars)"}, status=400
+                        {"error": "mpd_hw_volume must be an integer 1-100"}, status=400
                     )
             result = await manager.update_device_settings(address, settings)
             if result is None:

--- a/src/bt_audio_manager/web/static/app.js
+++ b/src/bt_audio_manager/web/static/app.js
@@ -354,9 +354,8 @@ function renderDevices(devices) {
         const kaMethod = d.keep_alive_method || "infrasound";
         const mpdEnabled = d.mpd_enabled || false;
         const mpdPort = d.mpd_port || "";
-        const mpdName = d.mpd_name || "";
+        const mpdHwVolume = d.mpd_hw_volume ?? 100;
         const safeName = escapeHtml(d.name).replace(/'/g, "\\'");
-        const safeMpdName = escapeHtml(mpdName).replace(/'/g, "\\'");
         kebab = `
           <div class="dropdown">
             <button class="btn btn-sm btn-link text-muted p-0 ms-2" type="button"
@@ -364,7 +363,7 @@ function renderDevices(devices) {
               <i class="fas fa-ellipsis-v"></i>
             </button>
             <ul class="dropdown-menu dropdown-menu-end">
-              <li><a class="dropdown-item" href="#" onclick="openDeviceSettings('${d.address}', '${safeName}', ${kaEnabled}, '${kaMethod}', ${mpdEnabled}, '${mpdPort}', '${safeMpdName}'); return false;">
+              <li><a class="dropdown-item" href="#" onclick="openDeviceSettings('${d.address}', '${safeName}', ${kaEnabled}, '${kaMethod}', ${mpdEnabled}, '${mpdPort}', ${mpdHwVolume}); return false;">
                 <i class="fas fa-cog me-2"></i>Settings
               </a></li>
               ${d.connected ? `<li><a class="dropdown-item" href="#" onclick="forceReconnectDevice('${d.address}'); return false;">
@@ -423,7 +422,7 @@ function renderDevices(devices) {
                 <h5 class="card-title mb-0" title="${escapeHtml(d.name)}">${escapeHtml(d.name)}</h5>
                 <div class="d-flex align-items-center gap-1">
                   ${keepAliveActive ? '<i class="fas fa-heartbeat text-danger keep-alive-indicator" title="Keep-alive active"></i>' : ""}
-                  ${mpdActive ? `<i class="fas fa-music text-primary" title="MPD: ${escapeHtml(d.mpd_name || d.name)} (port ${d.mpd_port || '?'})"></i>` : ""}
+                  ${mpdActive ? `<i class="fas fa-music text-primary" title="MPD: port ${d.mpd_port || '?'}"></i>` : ""}
                   <span class="badge ${badgeClass}">${statusText}</span>
                   ${kebab}
                 </div>
@@ -921,14 +920,14 @@ async function saveSettings() {
 
 let _settingsAddress = null;
 
-function openDeviceSettings(address, name, kaEnabled, kaMethod, mpdEnabled, mpdPort, mpdName) {
+function openDeviceSettings(address, name, kaEnabled, kaMethod, mpdEnabled, mpdPort, mpdHwVolume) {
   _settingsAddress = address;
   $("#device-settings-name").textContent = name;
   $("#device-settings-address").textContent = address;
   $("#setting-keep-alive-enabled").checked = kaEnabled;
   $("#setting-keep-alive-method").value = kaMethod || "infrasound";
   $("#setting-mpd-enabled").checked = mpdEnabled || false;
-  $("#setting-mpd-name").value = mpdName || "";
+  $("#setting-mpd-hw-volume").value = mpdHwVolume ?? 100;
   $("#setting-mpd-port").value = mpdPort || "";
   // Show connection info if port is assigned
   if (mpdPort) {
@@ -962,7 +961,7 @@ async function saveDeviceSettings() {
   };
   // Include MPD config when enabled
   if (settings.mpd_enabled) {
-    settings.mpd_name = $("#setting-mpd-name").value.trim();
+    settings.mpd_hw_volume = parseInt($("#setting-mpd-hw-volume").value, 10) || 100;
     const portVal = $("#setting-mpd-port").value;
     if (portVal) settings.mpd_port = parseInt(portVal, 10);
   }

--- a/src/bt_audio_manager/web/static/index.html
+++ b/src/bt_audio_manager/web/static/index.html
@@ -360,11 +360,12 @@
           <!-- MPD Config (shown when enabled) -->
           <div id="mpd-config-group" style="display:none;">
             <div class="mb-3">
-              <label for="setting-mpd-name" class="form-label">MPD Name</label>
-              <input type="text" class="form-control" id="setting-mpd-name"
-                     placeholder="(defaults to speaker name)" maxlength="64">
+              <label for="setting-mpd-hw-volume" class="form-label">Hardware Volume (%)</label>
+              <input type="number" class="form-control" id="setting-mpd-hw-volume"
+                     min="1" max="100" step="1" value="100">
               <div class="form-text">
-                Name shown in MPD clients and HA. Leave blank to use the Bluetooth device name.
+                Sets speaker hardware volume when MPD starts (1&ndash;100%). MPD then controls
+                perceived loudness as a single volume knob. Default: 100%.
               </div>
             </div>
             <div class="mb-3">


### PR DESCRIPTION
## Summary
- Removes user-facing `mpd_name` field (auto-generated from device name + MAC suffix instead)
- Adds `mpd_hw_volume` setting (1-100%, default 100%) to control speaker hardware volume on MPD init
- `_init_mpd_volume` uses the configured value instead of hardcoded 100%

This commit was stranded on the old `feature/mpd-volume-sync` branch — it was pushed after PR #73 was already merged, so it never landed on `dev`.

## Test plan
- [ ] Settings modal shows "Hardware Volume (%)" instead of "MPD Name"
- [ ] Saving a custom hw_volume (e.g. 80%) persists and is used on next MPD start
- [ ] MPD name auto-generated correctly (device name + last 5 MAC chars)

🤖 Generated with [Claude Code](https://claude.com/claude-code)