### PR TITLE
Fix kebab menu broken by unescaped double quotes in uuidsJson

### DIFF
--- a/src/bt_audio_manager/web/static/app.js
+++ b/src/bt_audio_manager/web/static/app.js
@@ -357,7 +357,7 @@ function renderDevices(devices) {
         const mpdHwVolume = d.mpd_hw_volume ?? 100;
         const avrcpEnabled = d.avrcp_enabled ?? true;
         const safeName = escapeHtml(d.name).replace(/'/g, "\\'");
-        const uuidsJson = JSON.stringify(d.uuids || []).replace(/'/g, "\\'");
+        const uuidsJson = JSON.stringify(d.uuids || []).replace(/"/g, '&quot;').replace(/'/g, "\\'");
         kebab = `
           <div class="dropdown">
             <button class="btn btn-sm btn-link text-muted p-0 ms-2" type="button"


### PR DESCRIPTION
## Summary
- `JSON.stringify` on the device UUID array produces double quotes that broke the `onclick="..."` HTML attribute in the kebab dropdown menu
- HTML-encode with `&quot;` so the browser decodes them back to `"` before JavaScript executes

## Test plan
- [ ] Open web UI, verify kebab (three-dot) menu opens on each device card
- [ ] Click "Settings" in the dropdown — device settings modal should open
- [ ] Verify AVRCP toggle correctly reflects device UUID support (enabled vs greyed out)

🤖 Generated with [Claude Code](https://claude.com/claude-code)