### PR TITLE
Unified idle mode: 4-mode When Idle system

### DIFF
--- a/src/bt_audio_manager/audio/pulse.py
+++ b/src/bt_audio_manager/audio/pulse.py
@@ -381,6 +381,38 @@ class PulseAudioManager:
             logger.debug("get_sink_volume(%s) failed: %s", sink_name, e)
         return None
 
+    async def suspend_sink(self, sink_name: str) -> bool:
+        """Suspend a sink to release the A2DP transport."""
+        if not self._pulse:
+            return False
+        try:
+            sinks = await self._pulse.sink_list()
+            for sink in sinks:
+                if sink.name == sink_name:
+                    await self._pulse.sink_suspend(sink.index, suspend=True)
+                    logger.info("Suspended PA sink: %s", sink_name)
+                    return True
+            logger.warning("Sink not found for suspend: %s", sink_name)
+        except Exception as e:
+            logger.warning("Failed to suspend sink %s: %s", sink_name, e)
+        return False
+
+    async def resume_sink(self, sink_name: str) -> bool:
+        """Resume a previously suspended sink."""
+        if not self._pulse:
+            return False
+        try:
+            sinks = await self._pulse.sink_list()
+            for sink in sinks:
+                if sink.name == sink_name:
+                    await self._pulse.sink_suspend(sink.index, suspend=False)
+                    logger.info("Resumed PA sink: %s", sink_name)
+                    return True
+            logger.warning("Sink not found for resume: %s", sink_name)
+        except Exception as e:
+            logger.warning("Failed to resume sink %s: %s", sink_name, e)
+        return False
+
     async def set_sink_volume(self, sink_name: str, volume_pct: int) -> bool:
         """Set PulseAudio sink volume (0-100%).
 

--- a/src/bt_audio_manager/web/api.py
+++ b/src/bt_audio_manager/web/api.py
@@ -293,7 +293,8 @@ def create_api_routes(
 
             body = await request.json()
             allowed_keys = {
-                "keep_alive_enabled", "keep_alive_method",
+                "idle_mode", "keep_alive_method",
+                "power_save_delay", "auto_disconnect_minutes",
                 "mpd_enabled", "mpd_port", "mpd_hw_volume",
                 "avrcp_enabled",
             }
@@ -302,16 +303,29 @@ def create_api_routes(
                 return web.json_response(
                     {"error": "No valid settings provided"}, status=400
                 )
+            if "idle_mode" in settings:
+                valid_modes = ("default", "power_save", "keep_alive", "auto_disconnect")
+                if settings["idle_mode"] not in valid_modes:
+                    return web.json_response(
+                        {"error": f"idle_mode must be one of {valid_modes}"}, status=400
+                    )
             if "keep_alive_method" in settings:
                 if settings["keep_alive_method"] not in ("silence", "infrasound"):
                     return web.json_response(
                         {"error": "keep_alive_method must be 'silence' or 'infrasound'"},
                         status=400,
                     )
-            if "keep_alive_enabled" in settings:
-                if not isinstance(settings["keep_alive_enabled"], bool):
+            if "power_save_delay" in settings:
+                val = settings["power_save_delay"]
+                if not isinstance(val, int) or val < 0 or val > 300:
                     return web.json_response(
-                        {"error": "keep_alive_enabled must be a boolean"}, status=400
+                        {"error": "power_save_delay must be 0-300 seconds"}, status=400
+                    )
+            if "auto_disconnect_minutes" in settings:
+                val = settings["auto_disconnect_minutes"]
+                if not isinstance(val, int) or val < 5 or val > 60:
+                    return web.json_response(
+                        {"error": "auto_disconnect_minutes must be 5-60"}, status=400
                     )
             if "mpd_enabled" in settings:
                 if not isinstance(settings["mpd_enabled"], bool):

--- a/src/bt_audio_manager/web/static/index.html
+++ b/src/bt_audio_manager/web/static/index.html
@@ -314,28 +314,52 @@
           <h6 id="device-settings-name" class="fw-semibold mb-1"></h6>
           <p id="device-settings-address" class="font-monospace small text-muted mb-3"></p>
 
-          <!-- Keep-Alive Toggle -->
+          <!-- When Idle -->
           <div class="mb-3">
-            <div class="form-check form-switch">
-              <input class="form-check-input" type="checkbox" id="setting-keep-alive-enabled">
-              <label class="form-check-label" for="setting-keep-alive-enabled">
-                <strong>Keep-Alive</strong>
-              </label>
-            </div>
-            <div class="form-text">
-              Stream inaudible audio to prevent the speaker from auto-shutting down during silence.
+            <label for="setting-idle-mode" class="form-label"><strong>When Idle</strong></label>
+            <select class="form-select" id="setting-idle-mode" onchange="toggleIdleModeOptions()">
+              <option value="default">Default (do nothing)</option>
+              <option value="power_save">Power Save (let speaker sleep)</option>
+              <option value="keep_alive">Stay Awake (stream silence)</option>
+              <option value="auto_disconnect">Auto-Disconnect</option>
+            </select>
+            <div class="form-text" id="idle-mode-help"></div>
+          </div>
+
+          <!-- Power Save options (shown when power_save selected) -->
+          <div id="power-save-options" style="display:none;">
+            <div class="mb-3">
+              <label for="setting-power-save-delay" class="form-label">Delay before suspending</label>
+              <select class="form-select" id="setting-power-save-delay">
+                <option value="0">Immediately</option>
+                <option value="30">30 seconds</option>
+                <option value="60">1 minute</option>
+                <option value="300">5 minutes</option>
+              </select>
             </div>
           </div>
 
-          <!-- Keep-Alive Method -->
-          <div class="mb-3" id="keep-alive-method-group">
-            <label for="setting-keep-alive-method" class="form-label">Keep-Alive Method</label>
-            <select class="form-select" id="setting-keep-alive-method">
-              <option value="infrasound">Infrasound (2 Hz tone &mdash; recommended)</option>
-              <option value="silence">Silence (PCM zeros)</option>
-            </select>
-            <div class="form-text">
-              Infrasound is recommended for speakers that detect digital silence.
+          <!-- Keep-Alive options (shown when keep_alive selected) -->
+          <div id="keep-alive-options" style="display:none;">
+            <div class="mb-3">
+              <label for="setting-keep-alive-method" class="form-label">Method</label>
+              <select class="form-select" id="setting-keep-alive-method">
+                <option value="infrasound">Infrasound (2 Hz tone &mdash; recommended)</option>
+                <option value="silence">Silence (PCM zeros)</option>
+              </select>
+            </div>
+          </div>
+
+          <!-- Auto-Disconnect options (shown when auto_disconnect selected) -->
+          <div id="auto-disconnect-options" style="display:none;">
+            <div class="mb-3">
+              <label for="setting-auto-disconnect-minutes" class="form-label">Disconnect after</label>
+              <select class="form-select" id="setting-auto-disconnect-minutes">
+                <option value="5">5 minutes</option>
+                <option value="15">15 minutes</option>
+                <option value="30">30 minutes</option>
+                <option value="60">1 hour</option>
+              </select>
             </div>
           </div>
 


### PR DESCRIPTION
## Summary
- Replaces the simple keep-alive on/off toggle with a unified **When Idle** dropdown offering 4 modes:
  - **Default** — do nothing (sink stays idle, transport held open, speaker uses its own sleep timer)
  - **Power Save** — suspend PA sink to release A2DP transport, letting the speaker enter power-save (configurable delay 0–300s)
  - **Stay Awake** — stream silence/infrasound to prevent speaker auto-shutdown (existing keep-alive behaviour)
  - **Auto-Disconnect** — fully disconnect BT device after configurable idle timeout (5–60 min)
- Legacy `keep_alive_enabled` settings are auto-migrated to `idle_mode` on read
- Device cards show mode-specific icons: moon (power save), heartbeat (stay awake), plug (auto-disconnect)
- PA sink suspend/resume via `pulsectl-asyncio` `sink_suspend()` API
- Idle mode handlers are lifecycle-managed: cancelled on audio resume, device disconnect, or mode change

## Files Changed
| File | Change |
|------|--------|
| `persistence/store.py` | New `idle_mode` default + legacy migration in `get_device_settings()` |
| `audio/pulse.py` | `suspend_sink()` / `resume_sink()` methods |
| `manager.py` | Idle mode dispatcher, power-save suspend, auto-disconnect timer |
| `web/api.py` | Validation for `idle_mode`, `power_save_delay`, `auto_disconnect_minutes` |
| `web/static/index.html` | Idle mode dropdown with conditional sub-option groups |
| `web/static/app.js` | New UI wiring, card icons, settings modal |

## Test plan
- [ ] Fresh install: default mode = "Default", no icons, no suspend, no keepalive
- [ ] Set "Power Save" → play audio → stop → sink suspends after delay → speaker sleeps
- [ ] Set "Stay Awake" with infrasound → speaker stays awake (existing behaviour)
- [ ] Set "Auto-Disconnect" at 5 min → play → stop → device disconnects after 5 min
- [ ] Switch modes while connected → old handler stops, new handler starts
- [ ] Legacy migration: device with `keep_alive_enabled=true` → shows "Stay Awake" mode
- [ ] Reconnect after power-save suspend → audio plays normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)