### PR TITLE
Add logging improvements for sink states, BlueZ props, BLE noise

### DIFF
--- a/src/bt_audio_manager/manager.py
+++ b/src/bt_audio_manager/manager.py
@@ -198,10 +198,25 @@ class BluetoothAudioManager:
                     if iface_name == "org.bluez.Device1" and set(prop_names) <= _NOISY_PROPS:
                         pass
                     else:
-                        logger.info(
-                            "BlueZ PropertiesChanged: iface=%s props=%s path=%s",
-                            iface_name, prop_names, msg.path,
-                        )
+                        # Log values for key interfaces; just names for the rest
+                        _VALUE_IFACES = {
+                            "org.bluez.MediaTransport1",
+                            "org.bluez.Device1",
+                            "org.bluez.Adapter1",
+                        }
+                        if iface_name in _VALUE_IFACES and isinstance(changed, dict):
+                            props_str = " ".join(
+                                f"{k}={v.value}" for k, v in changed.items()
+                            )
+                            logger.info(
+                                "BlueZ PropertiesChanged: iface=%s %s path=%s",
+                                iface_name, props_str, msg.path,
+                            )
+                        else:
+                            logger.info(
+                                "BlueZ PropertiesChanged: iface=%s props=%s path=%s",
+                                iface_name, prop_names, msg.path,
+                            )
 
                     # During scanning, broadcast when UUIDs or Name change
                     # (UUIDs often arrive after InterfacesAdded)


### PR DESCRIPTION
## Summary
- Add logging for sink running/idle PlaybackStatus actions (Playing/Stopped set, AVRCP disabled skip)
- Suppress noisy BLE ServiceData property changes from logs (added to `_NOISY_PROPS`)
- Log BlueZ property values for key interfaces (MediaTransport1, Device1, Adapter1) instead of just property names
- Add UI sink state labels (Streaming/Idle/Suspended)

These were orphaned logging commits from `feature/avrcp-toggle` that were pushed after PR #77 merged.

## Test plan
- [ ] Verify sink running/idle transitions log PlaybackStatus actions
- [ ] Verify ServiceData changes no longer spam logs
- [ ] Verify BlueZ property changes show actual values for key interfaces
- [ ] Verify UI shows human-readable sink state labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)