### PR TITLE
Device card: capability badges and layout redesign

### DIFF
--- a/src/bt_audio_manager/web/static/style.css
+++ b/src/bt_audio_manager/web/static/style.css
@@ -419,6 +419,30 @@ h1, h2, h3, h4, h5, h6 {
   text-align: center;
 }
 
+/* Active capability badges on device cards */
+.cap-badge {
+  font-size: 0.65rem;
+  padding: 0.15rem 0.4rem;
+  border-radius: 3px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  display: inline-block;
+  line-height: 1.2;
+  min-width: unset;
+}
+
+/* Feature indicator badges in action row */
+.feature-badge {
+  font-size: 0.7rem;
+  padding: 0.2rem 0.5rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid;
+  background: transparent;
+  white-space: nowrap;
+  line-height: 1.4;
+}
+
 /* ============================================
    Events Log
    ============================================ */


### PR DESCRIPTION
## Summary
- Add colored **active capability badges** when connected: `BR/EDR`, `A2DP`, `AVRCP ✓`/`AVRCP ✗`, `HFP`
- Move idle mode + MPD indicators from title icon cluster to **outlined feature badges** in the action row
- Change profile list to `Supports: A2DP Sink · AVRCP Target · HFP` format (middot separator, muted text)
- Remove redundant `BR/EDR / A2DP` connection detail line (replaced by capability badges)
- Clean up title row: only device name + status badge + kebab menu

No backend changes — all data already available from `get_all_devices()`.

## Test plan
- [ ] Connected device shows colored capability badges (BR/EDR, A2DP, AVRCP, HFP)
- [ ] AVRCP badge shows ✓ (green) when enabled, ✗ (amber) when disabled
- [ ] Disconnected device shows no capability badges
- [ ] Profile "Supports:" line uses middot separators
- [ ] Idle mode badges appear in action row (Power Save, Stay Awake, Auto-Disconnect)
- [ ] MPD badge shows in action row with port number
- [ ] Title row is cleaner (no icon cluster)

🤖 Generated with [Claude Code](https://claude.com/claude-code)