### PR TITLE
Improve device settings help text clarity

### DIFF
--- a/src/bt_audio_manager/web/static/app.js
+++ b/src/bt_audio_manager/web/static/app.js
@@ -992,7 +992,7 @@ function openDeviceSettings(address, name, idleMode, kaMethod, powerSaveDelay, a
   avrcpToggle.checked = hasAvrcp ? (avrcpEnabled ?? true) : false;
   avrcpToggle.disabled = !hasAvrcp;
   if (hasAvrcp) {
-    avrcpHelp.textContent = "Track playback state and accept media-button commands from the speaker. Disable if the speaker won't enter power-save when idle.";
+    avrcpHelp.textContent = "Track playback state and accept media-button commands from the speaker. Media buttons may or may not work reliably depending on hardware.";
   } else {
     avrcpHelp.textContent = "Device does not support AVRCP media buttons.";
   }
@@ -1007,8 +1007,8 @@ function toggleIdleModeOptions() {
   $("#keep-alive-options").style.display = mode === "keep_alive" ? "" : "none";
   $("#auto-disconnect-options").style.display = mode === "auto_disconnect" ? "" : "none";
   const helpTexts = {
-    default: "Sink stays idle with transport held open. Speaker uses its own sleep timer.",
-    power_save: "Suspends the audio sink to release the A2DP transport, letting the speaker enter power-save.",
+    default: "No action taken when audio stops. Whether the speaker sleeps depends on its own hardware idle timer.",
+    power_save: "Suspends the audio sink after the delay to release the A2DP transport. The speaker's own internal sleep timer determines when it actually powers down.",
     keep_alive: "Streams inaudible audio to prevent the speaker from auto-shutting down during silence.",
     auto_disconnect: "Fully disconnects the Bluetooth device after the specified idle timeout.",
   };

--- a/src/bt_audio_manager/web/static/index.html
+++ b/src/bt_audio_manager/web/static/index.html
@@ -320,7 +320,7 @@
             <select class="form-select" id="setting-idle-mode" onchange="toggleIdleModeOptions()">
               <option value="default">Default (do nothing)</option>
               <option value="power_save">Power Save (let speaker sleep)</option>
-              <option value="keep_alive">Stay Awake (stream silence)</option>
+              <option value="keep_alive">Stay Awake</option>
               <option value="auto_disconnect">Auto-Disconnect</option>
             </select>
             <div class="form-text" id="idle-mode-help"></div>


### PR DESCRIPTION
## Summary
- **AVRCP help text**: Removed outdated "Disable if the speaker won't enter power-save when idle" (fixed in idle modes). Added "Media buttons may or may not work reliably depending on hardware."
- **Stay Awake dropdown**: Removed "(stream silence)" since there are two methods (infrasound/silence)
- **Default idle mode help**: Clarified that whether the speaker sleeps depends on its own hardware idle timer
- **Power Save help**: Clarified that the delay controls when we suspend the sink, and the speaker's internal sleep timer determines when it actually powers down

## Test plan
- [ ] Open device settings modal and verify AVRCP help text reads correctly
- [ ] Verify "Stay Awake" dropdown option no longer says "(stream silence)"
- [ ] Select each idle mode and verify help text is clear and accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)