### PR TITLE
Log viewer: deduplicate info and add ms timestamps

### DIFF
--- a/src/bt_audio_manager/web/log_handler.py
+++ b/src/bt_audio_manager/web/log_handler.py
@@ -34,7 +34,7 @@ class WebSocketLogHandler(logging.Handler):
                 "ts": record.created,
                 "level": record.levelname,
                 "logger": record.name,
-                "message": self.format(record),
+                "message": record.getMessage(),
             }
             self.recent_logs.append(entry)
             self._event_bus.emit("log_entry", entry)

--- a/src/bt_audio_manager/web/static/app.js
+++ b/src/bt_audio_manager/web/static/app.js
@@ -737,7 +737,8 @@ function renderSingleLogEntry(entry, isNew) {
   const el = document.createElement("div");
   el.className = `log-entry${isNew ? " new" : ""}`;
 
-  const ts = new Date(entry.ts * 1000).toLocaleTimeString();
+  const d = new Date(entry.ts * 1000);
+  const ts = d.toLocaleTimeString() + "." + String(d.getMilliseconds()).padStart(3, "0");
   const levelClass = entry.level.toLowerCase();
   const logger = (entry.logger || "").split(".").pop();
 


### PR DESCRIPTION
## Summary
- **Remove duplicate info from log messages**: The WebSocket log handler was using `self.format(record)` which applied the full `LOG_FORMAT` (timestamp, level, logger prefix) to the message text — duplicating the structured blue columns already rendered in the UI. Now uses `record.getMessage()` to send only the message content.
- **Add milliseconds to timestamps**: The blue timestamp column now shows `HH:MM:SS.mmm` for precise timing, useful for debugging race conditions and fast event sequences.

HAOS logs (stderr/console handler) are unaffected — they use a separate `logging.basicConfig()` formatter.

## Test plan
- [ ] Open log viewer — timestamps should show milliseconds (e.g. `10:38:02.285`)
- [ ] Log message column should show only the message text, not the `2026-02-13 10:38:02 [INFO] bt_audio_manager.foo:` prefix
- [ ] HAOS add-on logs (`ha addon logs`) should still show full format with timestamp/level/logger

🤖 Generated with [Claude Code](https://claude.com/claude-code)