### PR TITLE
Fix HFP profile switch, PA recovery, and discovery filtering

### DIFF
--- a/src/bt_audio_manager/web/api.py
+++ b/src/bt_audio_manager/web/api.py
@@ -671,7 +671,11 @@ def create_api_routes(
         try:
             # Send initial state so UI renders immediately
             devices = await manager.get_all_devices()
-            sinks = await manager.get_audio_sinks()
+            try:
+                sinks = await manager.get_audio_sinks()
+            except Exception:
+                logger.warning("PA unavailable during WS init — sending empty sinks")
+                sinks = []
             await ws.send_json({"type": "devices_changed", "devices": devices})
             await ws.send_json({"type": "sinks_changed", "sinks": sinks})
             await ws.send_json({

--- a/src/bt_audio_manager/web/static/app.js
+++ b/src/bt_audio_manager/web/static/app.js
@@ -1120,13 +1120,15 @@ function connectWebSocket() {
 
   ws.onopen = () => {
     console.log("[WS] Connected");
-    wsReconnectDelay = 1000;
+    // Don't reset backoff here — wait for first successful message
+    // (server may disconnect immediately if PA is unavailable)
     hideReconnectBanner();
     hideBanner(); // Clear any pending operation banner (e.g. adapter restart)
     setConnectionStatus("connected");
   };
 
   ws.onmessage = (e) => {
+    wsReconnectDelay = 1000; // Reset backoff on successful data
     const msg = JSON.parse(e.data);
     switch (msg.type) {
       case "devices_changed":


### PR DESCRIPTION
## Summary
- Filter out A2DP Source-only devices from BT discovery results
- Add dismiss button for discovered devices
- Show active audio profile (A2DP/HFP) with checkmark badge on device cards
- Fix HFP profile activation: reload PA module after null handler removal
- Activate HFP PA card profile for devices already connected at startup
- Fix PA module reload retry (3 attempts with 2s intervals) to handle transient "lock: Permission denied"
- Explicitly activate PA card profile when switching audio profile via settings (instead of relying on event chain)
- Auto-restart PA event monitor with exponential backoff when connection drops
- Graceful WS initial state when PA is unavailable (send empty sinks instead of crashing)
- Fix WS client backoff: only reset delay on first successful message, not on TCP connect

## Test plan
- [ ] Pair a new BT device — verify A2DP Source-only devices are filtered from discovery
- [ ] Dismiss a discovered device — verify it disappears from the list
- [ ] Switch a connected device from A2DP to HFP via kebab menu — verify profile activates and card shows HFP badge
- [ ] Switch back to A2DP — verify profile reverts correctly
- [ ] Restart add-on with HFP device connected — verify HFP profile activates at startup
- [ ] Simulate PA disruption — verify event monitor auto-restarts and WS stays connected with empty sinks

🤖 Generated with [Claude Code](https://claude.com/claude-code)