### PR TITLE
Async profile switch with full fallback chain and UI feedback

### DIFF
--- a/src/bt_audio_manager/web/static/app.js
+++ b/src/bt_audio_manager/web/static/app.js
@@ -1068,6 +1068,9 @@ function toggleMpdConfigVisibility() {
 
 async function saveDeviceSettings() {
   if (!_settingsAddress) return;
+  const btn = $("#btnSaveSettings");
+  btn.disabled = true;
+  btn.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span>Saving…';
   const idleMode = $("#setting-idle-mode").value;
   const settings = {
     audio_profile: $("#setting-audio-profile").value,
@@ -1099,6 +1102,9 @@ async function saveDeviceSettings() {
     bootstrap.Modal.getInstance($("#deviceSettingsModal"))?.hide();
   } catch (e) {
     showToast(`Failed to save settings: ${e.message}`, "error");
+  } finally {
+    btn.disabled = false;
+    btn.innerHTML = '<i class="fas fa-save me-1"></i>Save';
   }
 }
 
@@ -1185,6 +1191,9 @@ function connectWebSocket() {
         } else {
           hideBanner();
         }
+        break;
+      case "toast":
+        showToast(msg.message, msg.level || "info");
         break;
       default:
         console.log("[WS] Unknown message type:", msg.type);

--- a/src/bt_audio_manager/web/static/index.html
+++ b/src/bt_audio_manager/web/static/index.html
@@ -437,7 +437,7 @@
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-          <button type="button" class="btn btn-primary" onclick="saveDeviceSettings()">
+          <button type="button" class="btn btn-primary" id="btnSaveSettings" onclick="saveDeviceSettings()">
             <i class="fas fa-save me-1"></i>Save
           </button>
         </div>


### PR DESCRIPTION
## Summary
- Save button disables and shows spinner during API call to prevent duplicate submissions
- Profile activation runs as background task — modal closes immediately after settings are persisted
- Full 3-step HFP fallback chain: PA card profile → ConnectProfile(HFP) → reload PA module + reconnect
- New `toast` WS event type for backend-initiated toast notifications
- Clear error toast when HFP activation fails (no more silent revert to A2DP)
- Success toast confirms profile switch completed

## Test plan
- [ ] Open device settings, switch to HFP, click Save — button shows spinner, modal closes fast
- [ ] Verify only one settings save occurs (no duplicate toasts from double-clicking)
- [ ] If HFP activates successfully → green "Audio profile switched to HFP" toast
- [ ] If HFP fails → red error toast with actionable message
- [ ] Switch back to A2DP → green success toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)