### PR TITLE
Fix Supervisor audio restart: grant manager role

### DIFF
--- a/bluetooth_audio_manager/config.yaml
+++ b/bluetooth_audio_manager/config.yaml
@@ -16,6 +16,7 @@ boot: auto
 # Permissions (least privilege)
 host_dbus: true
 hassio_api: true
+hassio_role: manager
 homeassistant_api: true
 audio: true
 privileged:

--- a/bluetooth_audio_manager_dev/config.yaml
+++ b/bluetooth_audio_manager_dev/config.yaml
@@ -16,6 +16,7 @@ boot: auto
 # Permissions (least privilege)
 host_dbus: true
 hassio_api: true
+hassio_role: manager
 homeassistant_api: true
 audio: true
 privileged:


### PR DESCRIPTION
## Summary

- **Root cause found**: The Supervisor `/audio/restart` endpoint requires `ROLE_MANAGER`, but the add-on only had `hassio_api: true` which defaults to `ROLE_DEFAULT` (limited to `/.+/info` paths only). Every call was silently returning 403.
- **Fix**: Added `hassio_role: manager` to both `config.yaml` files so the fallback audio restart actually has permission to work.
- **Logging**: Upgraded Supervisor API error logging from `DEBUG` → `WARNING` so failures show the actual HTTP status/error instead of just `Failed to restart audio service via Supervisor API`.
- **Task exception**: Wrapped `_on_device_connected_async` in top-level try/except to prevent noisy "Task exception was never retrieved" errors when PA is in a bad state.

## Test plan

- [ ] Reinstall add-on (config change requires reinstall, not just rebuild)
- [ ] Switch a connected device to HFP via kebab menu
- [ ] Verify pactl load-module fails as before, but Supervisor audio restart now succeeds (look for `Audio service restart requested via Supervisor` in logs)
- [ ] After restart, HFP card profile should appear and activate
- [ ] Verify no "Task exception was never retrieved" in logs

> **Note**: The `hassio_role: manager` config change may require an add-on reinstall (not just rebuild) to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)