### PR TITLE
Fix startup crash on missing Device1 interface

### DIFF
--- a/src/bt_audio_manager/manager.py
+++ b/src/bt_audio_manager/manager.py
@@ -345,7 +345,7 @@ class BluetoothAudioManager:
                             await self.pulse.activate_bt_card_profile(addr, profile="hfp")
                     elif self._should_disconnect_hfp(addr):
                         await self._disconnect_hfp(addr)
-            except DBusError as e:
+            except Exception as e:
                 logger.debug("Could not initialize stored device %s: %s", addr, e)
 
         # 6a. Clean up stale BlueZ device cache — remove unpaired, disconnected


### PR DESCRIPTION
## Summary

- The startup device initialization loop only caught `DBusError`, but `InterfaceNotFoundError` (raised when a stored device no longer exists in BlueZ) is a separate `dbus_next` exception that doesn't inherit from `DBusError`.
- Changed to `except Exception` so the add-on gracefully skips stale devices instead of crashing.

## Test plan

- [ ] Start add-on with a device in the persistence store that is no longer paired in BlueZ
- [ ] Verify add-on starts successfully and logs "Could not initialize stored device" at debug level instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)