### PR TITLE
Fix HFP profile name for PA native backend

### DIFF
--- a/src/bt_audio_manager/audio/pulse.py
+++ b/src/bt_audio_manager/audio/pulse.py
@@ -358,8 +358,13 @@ class PulseAudioManager:
         card_name = "bluez_card." + address.replace(":", "_")
 
         if profile == "hfp":
-            # HFP/HSP: BlueZ uses "headset-head-unit", PipeWire may use "headset_head_unit"
-            candidates = ("headset-head-unit", "headset_head_unit")
+            # PA native HFP backend (HAOS default) uses "handsfree_head_unit";
+            # oFono backend uses "headset_head_unit"; PipeWire may use either
+            # with hyphens or underscores.
+            candidates = (
+                "handsfree_head_unit", "handsfree-head-unit",
+                "headset_head_unit", "headset-head-unit",
+            )
         else:
             # A2DP: PA uses "a2dp-sink", PipeWire may use "a2dp_sink"
             candidates = ("a2dp-sink", "a2dp_sink")


### PR DESCRIPTION
## Summary
- HAOS runs PulseAudio 17.0 with the **native** HFP backend, which names the card profile `handsfree_head_unit`
- Our code only checked for `headset_head_unit` / `headset-head-unit` (the **oFono** backend names)
- Every HFP activation attempt failed with "has no HFP profile" — even though the profile was there the whole time: `available profiles: ['a2dp_sink', 'handsfree_head_unit', 'off']`
- Added all four profile name variants: `handsfree_head_unit`, `handsfree-head-unit`, `headset_head_unit`, `headset-head-unit`

This single naming mismatch was the root cause of all HFP activation failures. The fallback chain (DisconnectProfile, PA restart, reconnect) from PRs #92-#93 was chasing the wrong problem — but remains useful for edge cases where the profile genuinely isn't available yet.

## Test plan
- [ ] Switch device to HFP in settings — should succeed on first attempt (no fallbacks needed)
- [ ] Log should show `PA card profile set: bluez_card.XX -> handsfree_head_unit` immediately
- [ ] No more "PA card has no HFP profile" warnings
- [ ] Switch back to A2DP — should still work
- [ ] Verify A2DP-only devices (e.g., Bose speaker) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)