### PR TITLE
Label non-AVRCP volume events as Transport, align Add Device tile

### DIFF
--- a/src/bt_audio_manager/web/static/app.js
+++ b/src/bt_audio_manager/web/static/app.js
@@ -337,7 +337,7 @@ function buildFeatureBadges(device) {
 // Cached sinks for merging into device cards
 let currentSinks = [];
 
-function renderAddDeviceTile() {
+function addDeviceTileHtml() {
   const scanLabel = isScanning
     ? (scanSecondsRemaining > 0 ? `Scanning\u2026 ${scanSecondsRemaining}s` : "Finishing\u2026")
     : "Add Device";
@@ -345,10 +345,9 @@ function renderAddDeviceTile() {
     ? '<i class="fas fa-spinner fa-spin"></i>'
     : '<i class="fas fa-plus"></i>';
   const scanClass = isScanning ? " scanning" : "";
-  const wrapper = $("#add-device-wrapper");
-  if (wrapper) {
-    wrapper.innerHTML = `
-      <div class="card add-device-tile${scanClass}" id="add-device-tile"
+  return `
+    <div class="col-md-6 col-lg-4">
+      <div class="card add-device-tile h-100${scanClass}" id="add-device-tile"
            onclick="scanDevices()" role="button" tabindex="0"
            title="Scan for nearby Bluetooth audio devices">
         <div class="card-body">
@@ -356,20 +355,20 @@ function renderAddDeviceTile() {
           <span>${scanLabel}</span>
         </div>
       </div>
-    `;
-  }
+    </div>
+  `;
 }
 
 function renderDevices(devices) {
   const grid = $("#devices-grid");
-  renderAddDeviceTile();
+  const tileHtml = addDeviceTileHtml();
 
   if (!devices || devices.length === 0) {
-    grid.innerHTML = "";
+    grid.innerHTML = tileHtml;
     return;
   }
 
-  grid.innerHTML = devices
+  grid.innerHTML = tileHtml + devices
     .map((d) => {
       const badgeClass = d.connected
         ? "badge-connected"
@@ -657,6 +656,13 @@ function appendMprisCommand(data) {
 const _lastVolumeEvent = {};  // address → {value, ts}
 const VOLUME_DEDUP_MS = 1500;
 
+function _deviceHasAvrcp(address) {
+  if (!address || !lastDevices) return false;
+  const dev = lastDevices.find((d) => d.address === address);
+  if (!dev || !dev.uuids) return false;
+  return dev.uuids.some((u) => u.startsWith("0000110c") || u.startsWith("0000110e"));
+}
+
 function appendAvrcpEvent(data) {
   // Deduplicate volume events (D-Bus, PulseAudio, and AVRCP can all fire)
   if (data.property === "Volume" && data.address) {
@@ -672,10 +678,15 @@ function appendAvrcpEvent(data) {
     ? JSON.stringify(data.value)
     : String(data.value);
 
+  // Label as "Transport" for devices without AVRCP UUIDs (e.g. initial A2DP volume)
+  const isAvrcp = _deviceHasAvrcp(data.address);
+  const label = isAvrcp ? "AVRCP" : "Transport";
+  const cssClass = isAvrcp ? "avrcp" : "transport";
+
   appendEventEntry(
-    "avrcp",
+    cssClass,
     `<span class="event-time">${escapeHtml(eventTime(data))}</span>`
-    + `<span class="event-type avrcp">AVRCP</span>`
+    + `<span class="event-type ${cssClass}">${label}</span>`
     + `<span class="event-content"><strong>${escapeHtml(data.property)}</strong> = `
     + `<span class="text-success">${escapeHtml(valueStr)}</span>`
     + deviceNameTag(data.address)

--- a/src/bt_audio_manager/web/static/index.html
+++ b/src/bt_audio_manager/web/static/index.html
@@ -78,7 +78,6 @@
         </div>
       </div>
       <div class="devices-layout">
-        <div id="add-device-wrapper"></div>
         <div id="devices-grid" class="row g-3">
           <div class="col-12 text-center py-5">
             <p class="text-muted">Click "Add Device" to discover nearby Bluetooth audio devices, or "Refresh" to see paired devices.</p>

--- a/src/bt_audio_manager/web/static/style.css
+++ b/src/bt_audio_manager/web/static/style.css
@@ -252,36 +252,25 @@ h1, h2, h3, h4, h5, h6 {
    Devices Layout (Add-Device in left margin)
    ============================================ */
 
-.devices-layout {
-  position: relative;
-}
-
-/* Default: horizontal pill above the grid */
-#add-device-wrapper {
-  margin-bottom: 0.75rem;
-}
-
 .add-device-tile {
   border: 2px dashed var(--bs-border-color);
   cursor: pointer;
-  display: inline-block;
   transition: transform var(--transition-base), border-color var(--transition-base);
 }
 
 .add-device-tile .card-body {
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
   gap: 0.5rem;
-  padding: 0.5rem 1rem;
   color: var(--bs-secondary-color);
   font-weight: 500;
   font-size: 0.875rem;
-  white-space: nowrap;
 }
 
 .add-device-tile .card-body i {
-  font-size: 1rem;
+  font-size: 1.25rem;
 }
 
 .add-device-tile:hover {
@@ -305,23 +294,6 @@ h1, h2, h3, h4, h5, h6 {
 @keyframes scan-pulse {
   0%, 100% { border-color: var(--accent-primary); opacity: 1; }
   50% { border-color: var(--bs-border-color); opacity: 0.7; }
-}
-
-/* Wide screens: vertical button in the left margin */
-@media (min-width: 1440px) {
-  #add-device-wrapper {
-    position: absolute;
-    right: calc(100% + 0.75rem);
-    top: 0;
-    margin-bottom: 0;
-  }
-
-  .add-device-tile .card-body {
-    flex-direction: column;
-    gap: 0.25rem;
-    padding: 0.75rem 0.5rem;
-    font-size: 0.75rem;
-  }
 }
 
 /* ============================================
@@ -492,6 +464,11 @@ h1, h2, h3, h4, h5, h6 {
 .event-type.avrcp {
   background: rgba(59, 130, 246, 0.15);
   color: var(--accent-primary);
+}
+
+.event-type.transport {
+  background: rgba(20, 184, 166, 0.15);
+  color: #14b8a6;
 }
 
 .event-content {


### PR DESCRIPTION
## Summary
- **Transport label**: Volume events from devices without AVRCP UUIDs (e.g. Jabra SPEAK 510 USB) now show a teal "Transport" badge instead of blue "AVRCP" — prevents confusion about AVRCP support when the event is just the initial A2DP `MediaTransport1.Volume` property
- **Add Device tile alignment**: Moved tile into the Bootstrap grid row (`col-md-6 col-lg-4`) with `h-100` so it matches device card height. Top/bottom edges align, text is vertically centered. Removed the old absolute-positioning approach for wide screens

## Test plan
- [ ] Verify Jabra (no AVRCP UUIDs) shows "Transport" badge in teal on volume events
- [ ] Verify Bose (has AVRCP UUIDs) still shows "AVRCP" badge in blue on volume/button events
- [ ] Verify Add Device tile top edge aligns with device card top edge
- [ ] Verify Add Device tile bottom edge aligns with device card bottom edge
- [ ] Verify "+ Add Device" text is vertically centered in the tile
- [ ] Verify scanning animation still works on the tile
- [ ] Verify layout at different screen widths (mobile, tablet, desktop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)