### PR TITLE
Center Add Device tile text horizontally on wide screens

### DIFF
--- a/src/bt_audio_manager/web/static/style.css
+++ b/src/bt_audio_manager/web/static/style.css
@@ -332,6 +332,7 @@ h1, h2, h3, h4, h5, h6 {
     padding: 0.75rem 0.5rem;
     font-size: 0.75rem;
     white-space: normal;
+    text-align: center;
   }
 }
 


### PR DESCRIPTION
## Summary
- Add `text-align: center` to the wide-screen card-body so "Add Device" text centers horizontally when wrapping across lines

## Test plan
- [ ] Verify "+" icon and "Add Device" text are centered horizontally in the tile on wide screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)