### PR TITLE
Fix MPD port display, remove connection badge, fix WS flicker

### DIFF
--- a/src/bt_audio_manager/web/static/index.html
+++ b/src/bt_audio_manager/web/static/index.html
@@ -71,7 +71,6 @@
       <div class="d-flex justify-content-between align-items-center mb-3">
         <h2 class="mb-0">Devices</h2>
         <div class="d-flex align-items-center gap-2">
-          <span id="connection-status" class="badge bg-secondary">Connecting...</span>
           <button type="button" id="btn-refresh" class="btn btn-outline-secondary btn-sm" onclick="refreshDevices()">
             <i class="fas fa-sync-alt me-1"></i>Refresh
           </button>

--- a/src/bt_audio_manager/web/static/style.css
+++ b/src/bt_audio_manager/web/static/style.css
@@ -204,12 +204,6 @@ h1, h2, h3, h4, h5, h6 {
   transform: translateY(-1px);
 }
 
-/* Connection status badge consistent width */
-#connection-status {
-  min-width: 85px;
-  text-align: center;
-}
-
 /* Server unavailable — dims device cards and disables interaction */
 .server-unavailable .device-card {
   opacity: 0.45;


### PR DESCRIPTION
## Summary
- **MPD port pre-fill**: When enabling MPD for the first time on a device, the next available port (6600–6609) is now shown immediately instead of appearing blank until save
- **Connection status badge removed**: The green "Connected" / yellow "Reconnecting..." badge pill is removed — the reconnect banner already communicates connection state
- **WebSocket banner flicker fix**: "Connected" state is deferred to the first real WebSocket message (not TCP open), preventing the reconnect banner from flickering when the server closes the connection immediately

## Test plan
- [ ] Enable MPD on a device that doesn't have it yet — port field should show next available (e.g. 6600)
- [ ] Verify no green/yellow badge appears next to the Refresh button
- [ ] Stop the server and verify the reconnect banner stays visible without flickering during reconnect cycles
- [ ] Verify the banner disappears once the server is back and sends data

🤖 Generated with [Claude Code](https://claude.com/claude-code)