### PR TITLE
Adjust BT device tile metadata text to 0.75rem

### DIFF
--- a/src/bt_audio_manager/web/static/app.js
+++ b/src/bt_audio_manager/web/static/app.js
@@ -462,8 +462,8 @@ function renderDevices(devices) {
                 </div>
               </div>
               ${buildCapBadges(d)}
-              <div class="font-monospace small text-muted">${escapeHtml(d.address)}${rssiDisplay}${d.adapter ? ` on ${escapeHtml(d.adapter)}` : ""}</div>
-              ${profiles ? `<div class="small mt-1 text-muted">${escapeHtml(profiles)}</div>` : ""}
+              <div class="device-meta-text font-monospace text-muted">${escapeHtml(d.address)}${rssiDisplay}${d.adapter ? ` on ${escapeHtml(d.adapter)}` : ""}</div>
+              ${profiles ? `<div class="device-meta-text mt-1 text-muted">${escapeHtml(profiles)}</div>` : ""}
               ${sinkInfo}
               <div class="device-actions d-flex gap-2 flex-wrap">
                 ${buildFeatureBadges(d)}

--- a/src/bt_audio_manager/web/static/style.css
+++ b/src/bt_audio_manager/web/static/style.css
@@ -401,6 +401,10 @@ h1, h2, h3, h4, h5, h6 {
   flex-direction: column;
 }
 
+.device-meta-text {
+  font-size: 0.75rem;
+}
+
 /* Container minimum height to prevent collapse during loading */
 #devices-grid {
   min-height: 200px;


### PR DESCRIPTION
### Motivation
- Reduce the font size of the two metadata lines shown on Bluetooth device tiles (address/adapter and supported profiles) to `0.75rem` as requested.

### Description
- Replaced the Bootstrap `small` usage for the address/adapter and profile lines with a new `device-meta-text` class in `src/bt_audio_manager/web/static/app.js` so only those two lines are targeted. 
- Added a CSS rule `.device-meta-text { font-size: 0.75rem; }` in `src/bt_audio_manager/web/static/style.css` to apply the requested sizing.

### Testing
- Ran `python -m compileall -q src` to ensure no syntax errors in the Python source and it completed successfully. 
- Generated a visual verification screenshot by serving the static files with `python -m http.server` and running a Playwright rendering script, which produced the updated tile preview image successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698fe0d0423c83229404be410b6c9967)