### PR TITLE
Align device sink info row across device cards

### DIFF
--- a/src/bt_audio_manager/web/static/app.js
+++ b/src/bt_audio_manager/web/static/app.js
@@ -463,7 +463,7 @@ function renderDevices(devices) {
               </div>
               ${buildCapBadges(d)}
               <div class="device-meta-text font-monospace text-muted">${escapeHtml(d.address)}${rssiDisplay}${d.adapter ? ` on ${escapeHtml(d.adapter)}` : ""}</div>
-              ${profiles ? `<div class="device-meta-text mt-1 text-muted">${escapeHtml(profiles)}</div>` : ""}
+              ${profiles ? `<div class="device-meta-text device-profiles-text mt-1 text-muted">${escapeHtml(profiles)}</div>` : ""}
               ${sinkInfo}
               <div class="device-actions d-flex gap-2 flex-wrap">
                 ${buildFeatureBadges(d)}

--- a/src/bt_audio_manager/web/static/style.css
+++ b/src/bt_audio_manager/web/static/style.css
@@ -405,6 +405,10 @@ h1, h2, h3, h4, h5, h6 {
   font-size: 0.75rem;
 }
 
+.device-profiles-text {
+  min-height: 2.4em;
+}
+
 /* Container minimum height to prevent collapse during loading */
 #devices-grid {
   min-height: 200px;


### PR DESCRIPTION
### Motivation
- Ensure the device audio sink line (sample rate / channels / format / volume / state) appears at a consistent vertical position across all device tiles so it lines up just above the status badge and button area.

### Description
- Add a dedicated `device-profiles-text` class to the rendered profile/supports row in `src/bt_audio_manager/web/static/app.js` and reserve vertical space by adding `min-height: 2.4em` for `.device-profiles-text` in `src/bt_audio_manager/web/static/style.css`.

### Testing
- Ran `node --check src/bt_audio_manager/web/static/app.js` which succeeded. 
- Ran `pytest -q` which reported no tests were run for this repository (no failing tests were produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698fe34d8cc083229e2024e80d254003)