### PR TITLE
Stack feature badges above action button on device cards

### DIFF
--- a/src/bt_audio_manager/web/static/app.js
+++ b/src/bt_audio_manager/web/static/app.js
@@ -465,9 +465,9 @@ function renderDevices(devices) {
               <div class="device-meta-text font-monospace text-muted">${escapeHtml(d.address)}${rssiDisplay}${d.adapter ? ` on ${escapeHtml(d.adapter)}` : ""}</div>
               ${profiles ? `<div class="device-meta-text device-profiles-text mt-1 text-muted">${escapeHtml(profiles)}</div>` : ""}
               ${sinkInfo}
-              <div class="device-actions d-flex gap-2 flex-wrap">
-                ${buildFeatureBadges(d)}
-                <span class="ms-auto">${actions}</span>
+              ${(() => { const fb = buildFeatureBadges(d); return fb ? `<div class="device-feature-badges d-flex gap-2 flex-wrap">${fb}</div>` : ""; })()}
+              <div class="device-actions">
+                ${actions}
               </div>
             </div>
           </div>

--- a/src/bt_audio_manager/web/static/style.css
+++ b/src/bt_audio_manager/web/static/style.css
@@ -420,10 +420,14 @@ h1, h2, h3, h4, h5, h6 {
   min-height: 200px;
 }
 
+.device-card .device-feature-badges {
+  margin-top: 0.5rem;
+}
+
 .device-card .device-actions {
   margin-top: auto;
   padding-top: 0.5rem;
-  align-items: center;
+  text-align: center;
 }
 
 /* Status badges */


### PR DESCRIPTION
## Summary
- Separates feature badges (Power Save, MPD :6600) from the Disconnect button into their own row
- Prevents awkward wrapping when badges and button compete for space on narrow cards (3-col direct access and 2-col HA ingress views)
- Cards with no feature badges (e.g. no Power Save / no MPD) show just the centered Disconnect button with no empty badge row

## Test plan
- [ ] Load UI at wide viewport (3 cards per row) — feature badges on their own line, Disconnect button centered below
- [ ] Load through HA ingress (2 cards per row) — same clean separation
- [ ] Verify card with no feature badges shows just the Disconnect button
- [ ] Verify card height consistency across cards with/without feature badges

🤖 Generated with [Claude Code](https://claude.com/claude-code)