### PR TITLE
Fix adapter Select button broken by apostrophes in names

### DIFF
--- a/src/bt_audio_manager/web/static/app.js
+++ b/src/bt_audio_manager/web/static/app.js
@@ -523,7 +523,7 @@ function renderAdaptersModal(adapters) {
       const displayLabel = friendlyName || a.name;
       const selectBtn =
         !a.selected && a.powered
-          ? `<button type="button" class="btn btn-sm btn-primary" onclick="selectAdapter('${a.address}', '${escapeHtml(displayLabel)}')">
+          ? `<button type="button" class="btn btn-sm btn-primary" onclick="selectAdapter('${a.address}', '${escapeHtml(displayLabel).replace(/'/g, "\\'")}')">
                <i class="fas fa-check me-1"></i>Select
              </button>`
           : "";


### PR DESCRIPTION
## Summary
- Escape apostrophes in adapter `displayLabel` at the `onclick` injection point
- Prevents adapter names containing `'` (e.g. "King's USB BT") from breaking the generated JS string and making the Select button non-functional
- Uses the same `escapeHtml().replace(/'/g, "\\'")` pattern already used for device names on line 401

## Test plan
- [ ] Open adapter modal — Select button works for adapters with normal names
- [ ] If possible, test with an adapter whose alias contains an apostrophe

🤖 Generated with [Claude Code](https://claude.com/claude-code)