### PR TITLE
Fix security and quality issues from codebase audit

### DIFF
--- a/src/bt_audio_manager/audio/mpd.py
+++ b/src/bt_audio_manager/audio/mpd.py
@@ -169,8 +169,8 @@ class MPDManager:
             pid_file=self._pid_file,
             port=self._port,
             password_line=password_line,
-            speaker_name=self._speaker_name,
-            sink=self._sink_name,
+            speaker_name=self._speaker_name.replace("\\", "\\\\").replace('"', '\\"'),
+            sink=self._sink_name.replace("\\", "\\\\").replace('"', '\\"'),
         )
 
         with open(self._conf_path, "w") as f:

--- a/src/bt_audio_manager/web/api.py
+++ b/src/bt_audio_manager/web/api.py
@@ -3,6 +3,7 @@
 import asyncio
 import logging
 import os
+import re
 from typing import TYPE_CHECKING
 
 from aiohttp import web
@@ -14,6 +15,9 @@ if TYPE_CHECKING:
     from .log_handler import WebSocketLogHandler
 
 logger = logging.getLogger(__name__)
+
+# Strict Bluetooth MAC address pattern (AA:BB:CC:DD:EE:FF)
+_MAC_RE = re.compile(r"^[0-9A-Fa-f]{2}(:[0-9A-Fa-f]{2}){5}$")
 
 # Map common BlueZ D-Bus error strings to user-friendly messages
 _BLUEZ_ERROR_MAP = {
@@ -38,7 +42,25 @@ def _friendly_error(e: Exception) -> str:
         for pattern, friendly in _BLUEZ_ERROR_MAP.items():
             if pattern in msg:
                 return friendly
-    return msg
+    # Don't leak raw D-Bus internals to the client
+    logger.debug("Unmapped error returned to client: %s", msg)
+    return "Operation failed. Check add-on logs for details."
+
+
+def _get_validated_address(body: dict) -> tuple[str | None, web.Response | None]:
+    """Extract and validate a Bluetooth MAC address from a request body.
+
+    Returns (address, None) on success or (None, error_response) on failure.
+    """
+    address = body.get("address")
+    if not address:
+        return None, web.json_response({"error": "address is required"}, status=400)
+    if not isinstance(address, str) or not _MAC_RE.match(address):
+        return None, web.json_response(
+            {"error": "Invalid Bluetooth address format (expected XX:XX:XX:XX:XX:XX)"},
+            status=400,
+        )
+    return address, None
 
 
 async def _ws_sender(
@@ -107,6 +129,17 @@ def create_api_routes(
             if not adapter_name:
                 return web.json_response(
                     {"error": "adapter is required"}, status=400
+                )
+            # Validate format: "auto", MAC address, or legacy hciN name
+            valid = (
+                adapter_name == "auto"
+                or _MAC_RE.match(adapter_name)
+                or re.match(r"^hci\d+$", adapter_name)
+            )
+            if not valid:
+                return web.json_response(
+                    {"error": "adapter must be 'auto', a MAC address, or an hciN name"},
+                    status=400,
                 )
 
             clean = body.get("clean", False)
@@ -196,11 +229,9 @@ def create_api_routes(
         address = None
         try:
             body = await request.json()
-            address = body.get("address")
-            if not address:
-                return web.json_response(
-                    {"error": "address is required"}, status=400
-                )
+            address, err = _get_validated_address(body)
+            if err:
+                return err
             result = await manager.pair_device(address)
             return web.json_response(result)
         except Exception as e:
@@ -213,11 +244,9 @@ def create_api_routes(
         address = None
         try:
             body = await request.json()
-            address = body.get("address")
-            if not address:
-                return web.json_response(
-                    {"error": "address is required"}, status=400
-                )
+            address, err = _get_validated_address(body)
+            if err:
+                return err
             success = await manager.connect_device(address)
             return web.json_response({"connected": success, "address": address})
         except Exception as e:
@@ -230,11 +259,9 @@ def create_api_routes(
         address = None
         try:
             body = await request.json()
-            address = body.get("address")
-            if not address:
-                return web.json_response(
-                    {"error": "address is required"}, status=400
-                )
+            address, err = _get_validated_address(body)
+            if err:
+                return err
             await manager.disconnect_device(address)
             return web.json_response({"disconnected": True, "address": address})
         except Exception as e:
@@ -247,11 +274,9 @@ def create_api_routes(
         address = None
         try:
             body = await request.json()
-            address = body.get("address")
-            if not address:
-                return web.json_response(
-                    {"error": "address is required"}, status=400
-                )
+            address, err = _get_validated_address(body)
+            if err:
+                return err
             success = await manager.force_reconnect_device(address)
             return web.json_response({"reconnected": success, "address": address})
         except Exception as e:
@@ -264,11 +289,9 @@ def create_api_routes(
         address = None
         try:
             body = await request.json()
-            address = body.get("address")
-            if not address:
-                return web.json_response(
-                    {"error": "address is required"}, status=400
-                )
+            address, err = _get_validated_address(body)
+            if err:
+                return err
             await manager.forget_device(address)
             return web.json_response({"forgotten": True, "address": address})
         except Exception as e:
@@ -279,6 +302,11 @@ def create_api_routes(
     async def update_device_settings(request: web.Request) -> web.Response:
         """Update per-device settings (keep-alive, etc.)."""
         address = request.match_info["address"]
+        if not _MAC_RE.match(address):
+            return web.json_response(
+                {"error": "Invalid Bluetooth address format (expected XX:XX:XX:XX:XX:XX)"},
+                status=400,
+            )
         try:
             # Auto-store paired devices not yet in the persistence store
             # (can happen when BlueZ paired a device before the add-on tracked it)
@@ -476,9 +504,9 @@ def create_api_routes(
         address = None
         try:
             body = await request.json()
-            address = body.get("address")
-            if not address:
-                return web.json_response({"error": "address is required"}, status=400)
+            address, err = _get_validated_address(body)
+            if err:
+                return err
             result = await manager.debug_avrcp_cycle(address)
             return web.json_response(result)
         except Exception as e:
@@ -491,9 +519,9 @@ def create_api_routes(
         address = None
         try:
             body = await request.json()
-            address = body.get("address")
-            if not address:
-                return web.json_response({"error": "address is required"}, status=400)
+            address, err = _get_validated_address(body)
+            if err:
+                return err
             result = await manager.debug_mpris_reregister(address)
             return web.json_response(result)
         except Exception as e:
@@ -506,9 +534,9 @@ def create_api_routes(
         address = None
         try:
             body = await request.json()
-            address = body.get("address")
-            if not address:
-                return web.json_response({"error": "address is required"}, status=400)
+            address, err = _get_validated_address(body)
+            if err:
+                return err
             result = await manager.debug_mpris_avrcp_cycle(address)
             return web.json_response(result)
         except Exception as e:
@@ -521,9 +549,9 @@ def create_api_routes(
         address = None
         try:
             body = await request.json()
-            address = body.get("address")
-            if not address:
-                return web.json_response({"error": "address is required"}, status=400)
+            address, err = _get_validated_address(body)
+            if err:
+                return err
             result = await manager.debug_disconnect_hfp(address)
             return web.json_response(result)
         except Exception as e:
@@ -536,9 +564,9 @@ def create_api_routes(
         address = None
         try:
             body = await request.json()
-            address = body.get("address")
-            if not address:
-                return web.json_response({"error": "address is required"}, status=400)
+            address, err = _get_validated_address(body)
+            if err:
+                return err
             result = await manager.debug_hfp_reconnect_cycle(address)
             return web.json_response(result)
         except Exception as e:

--- a/src/bt_audio_manager/web/events.py
+++ b/src/bt_audio_manager/web/events.py
@@ -29,7 +29,7 @@ class EventBus:
         if not self._clients:
             return
         logger.debug("EventBus emit: %s → %d client(s)", event, len(self._clients))
-        for q in self._clients:
+        for q in list(self._clients):
             try:
                 q.put_nowait({"event": event, "data": data})
             except asyncio.QueueFull:

--- a/src/bt_audio_manager/web/static/app.js
+++ b/src/bt_audio_manager/web/static/app.js
@@ -51,6 +51,17 @@ function escapeHtml(text) {
   return div.innerHTML;
 }
 
+function safeJsString(text) {
+  // Escape for embedding in a JS single-quoted string inside an HTML attribute.
+  // Order matters: backslashes first, then quotes and HTML-significant chars.
+  return (text || "")
+    .replace(/\\/g, "\\\\")
+    .replace(/'/g, "\\'")
+    .replace(/</g, "\\x3c")
+    .replace(/>/g, "\\x3e")
+    .replace(/&/g, "\\x26");
+}
+
 // ============================================
 // Section 2: Theme Detection
 // ============================================
@@ -398,8 +409,8 @@ function renderDevices(devices) {
         const mpdPort = d.mpd_port || "";
         const mpdHwVolume = d.mpd_hw_volume ?? 100;
         const avrcpEnabled = d.avrcp_enabled ?? true;
-        const safeName = escapeHtml(d.name).replace(/'/g, "\\'");
-        const uuidsJson = JSON.stringify(d.uuids || []).replace(/"/g, '&quot;').replace(/'/g, "\\'");
+        const safeName = safeJsString(d.name);
+        const uuidsJson = safeJsString(JSON.stringify(d.uuids || []));
         kebab = `
           <div class="dropdown">
             <button class="btn btn-sm btn-link text-muted p-0 ms-2" type="button"
@@ -523,7 +534,7 @@ function renderAdaptersModal(adapters) {
       const displayLabel = friendlyName || a.name;
       const selectBtn =
         !a.selected && a.powered
-          ? `<button type="button" class="btn btn-sm btn-primary" onclick="selectAdapter('${a.address}', '${escapeHtml(displayLabel).replace(/'/g, "\\'")}')">
+          ? `<button type="button" class="btn btn-sm btn-primary" onclick="selectAdapter('${a.address}', '${safeJsString(displayLabel)}')">
                <i class="fas fa-check me-1"></i>Select
              </button>`
           : "";


### PR DESCRIPTION
## Summary
- **Silent task failures**: Replaced all `asyncio.ensure_future()` with `create_task()` + error callback so exceptions in fire-and-forget tasks are logged instead of silently swallowed
- **Race condition**: Added per-device lifecycle lock around `connect_device()` post-setup (idle mode, MPD, HFP disconnect) to prevent racing with concurrent disconnect handlers across `await` points
- **Input validation**: Added strict MAC address format validation to all API endpoints accepting a Bluetooth address; added adapter format validation to `set-adapter`
- **MPD config injection**: Escaped double quotes and backslashes in device/sink names before interpolating into MPD config files
- **XSS hardening**: Added `safeJsString()` helper for proper JS string escaping in inline onclick attributes (handles backslashes, single quotes, and HTML-significant characters)
- **Info disclosure**: `_friendly_error()` no longer leaks raw D-Bus error strings to clients; returns a generic message and logs the detail server-side
- **Resource cleanup**: `forget_device()` now cleans up all per-address tracking dicts and stops idle handlers (keepalive, suspend timer, auto-disconnect)
- **Deprecation**: Replaced `asyncio.get_event_loop()` with `get_running_loop()`
- **Defensive hardening**: `EventBus.emit()` iterates a snapshot of the clients set

## Test plan
- [ ] Pair, connect, disconnect, and forget a device — verify no regressions
- [ ] Verify device settings modal opens correctly (tests `safeJsString` escaping)
- [ ] Check add-on logs for "Background task failed" entries (confirms error callback works)
- [ ] Send `POST /api/pair` with invalid address format — verify 400 response
- [ ] Send `POST /api/set-adapter` with invalid adapter — verify 400 response

🤖 Generated with [Claude Code](https://claude.com/claude-code)