### PR TITLE
Switch to multi-arch manifest images

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -71,24 +71,95 @@ jobs:
           VERSION=$(grep '^version:' bluetooth_audio_manager/config.yaml | sed 's/version: *"\?\([^"]*\)"\?/\1/')
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
-      - name: Build and push
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
           file: docker/Dockerfile
           platforms: ${{ matrix.platform }}
-          push: ${{ github.event_name != 'pull_request' }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
           build-args: |
             BUILD_FROM=ghcr.io/home-assistant/${{ matrix.arch }}-base:3.20
             BUILD_ARCH=${{ matrix.arch }}
             BUILD_DATE=${{ github.event.head_commit.timestamp }}
             BUILD_VERSION=${{ steps.version.outputs.version }}
             BUILD_SHA=${{ github.sha }}
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/${{ matrix.arch }}:${{ steps.version.outputs.version }}
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/${{ matrix.arch }}:latest
           cache-from: type=gha,scope=stable-${{ matrix.arch }}
           cache-to: type=gha,scope=stable-${{ matrix.arch }},mode=max
+
+      - name: Export digest
+        if: github.event_name != 'pull_request'
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: digest-${{ matrix.arch }}
+          path: /tmp/digests/*
+          retention-days: 1
+          if-no-files-found: error
+
+  # ==========================================================================
+  # Merge stable digests into a multi-arch manifest
+  # ==========================================================================
+  merge:
+    name: Create multi-arch manifest
+    needs: build
+    if: github.ref != 'refs/heads/dev' && github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digest-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract version from config.yaml
+        id: version
+        run: |
+          VERSION=$(grep '^version:' bluetooth_audio_manager/config.yaml | sed 's/version: *"\?\([^"]*\)"\?/\1/')
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=${{ steps.version.outputs.version }}
+            type=raw,value=latest
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
 
   # ==========================================================================
   # Dev build — runs only on dev branch pushes
@@ -139,31 +210,95 @@ jobs:
         id: short_sha
         run: echo "sha=$(echo ${{ github.sha }} | cut -c1-7)" >> "$GITHUB_OUTPUT"
 
-      - name: Build and push dev image
+      - name: Build and push dev image by digest
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
           file: docker/Dockerfile
           platforms: ${{ matrix.platform }}
-          push: true
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME_DEV }},push-by-digest=true,name-canonical=true,push=true
           build-args: |
             BUILD_FROM=ghcr.io/home-assistant/${{ matrix.arch }}-base:3.20
             BUILD_ARCH=${{ matrix.arch }}
             BUILD_DATE=${{ github.event.head_commit.timestamp }}
             BUILD_VERSION=sha-${{ steps.short_sha.outputs.sha }}
             BUILD_SHA=${{ github.sha }}
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_DEV }}/${{ matrix.arch }}:sha-${{ steps.short_sha.outputs.sha }}
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_DEV }}/${{ matrix.arch }}:latest
           cache-from: type=gha,scope=dev-${{ matrix.arch }}
           cache-to: type=gha,scope=dev-${{ matrix.arch }},mode=max
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digest-dev-${{ matrix.arch }}
+          path: /tmp/digests/*
+          retention-days: 1
+          if-no-files-found: error
+
+  # ==========================================================================
+  # Merge dev digests into a multi-arch manifest
+  # ==========================================================================
+  merge-dev:
+    name: Create multi-arch dev manifest
+    needs: build-dev
+    if: github.ref == 'refs/heads/dev'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digest-dev-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get short SHA
+        id: short_sha
+        run: echo "sha=$(echo ${{ github.sha }} | cut -c1-7)" >> "$GITHUB_OUTPUT"
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_DEV }}
+          tags: |
+            type=raw,value=sha-${{ steps.short_sha.outputs.sha }}
+            type=raw,value=latest
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME_DEV }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_DEV }}:sha-${{ steps.short_sha.outputs.sha }}
 
   # ==========================================================================
   # Update dev app version on main (after successful dev build)
   # ==========================================================================
   update-addon-version-dev:
     name: Update dev app version
-    needs: build-dev
+    needs: merge-dev
     if: github.ref == 'refs/heads/dev'
     runs-on: ubuntu-latest
     permissions:

--- a/bluetooth_audio_manager/config.yaml
+++ b/bluetooth_audio_manager/config.yaml
@@ -3,7 +3,7 @@ version: "1.0.0"
 slug: bluetooth_audio_manager
 description: "Manage Bluetooth audio device connections (A2DP) with persistent pairing, auto-reconnect, and AppArmor security."
 url: "https://github.com/scyto/ha-bluetooth-audio-manager"
-image: "ghcr.io/scyto/ha-bluetooth-audio-manager/{arch}"
+image: "ghcr.io/scyto/ha-bluetooth-audio-manager"
 arch:
   - aarch64
   - amd64

--- a/bluetooth_audio_manager_dev/config.yaml
+++ b/bluetooth_audio_manager_dev/config.yaml
@@ -3,7 +3,7 @@ version: "sha-6b00586"
 slug: bluetooth_audio_manager_dev
 description: "Development build - may be unstable. Bluetooth A2DP audio device management with persistent pairing and auto-reconnect."
 url: "https://github.com/scyto/ha-bluetooth-audio-manager"
-image: "ghcr.io/scyto/ha-bluetooth-audio-manager-dev/{arch}"
+image: "ghcr.io/scyto/ha-bluetooth-audio-manager-dev"
 arch:
   - aarch64
   - amd64


### PR DESCRIPTION
## Summary
- Replaces per-architecture GHCR packages (`/amd64`, `/aarch64`, etc.) with single multi-arch manifest images
- Each arch builds and pushes by digest, then a new `merge` job combines them via `docker buildx imagetools create`
- Removes `/{arch}` from the `image` field in both config.yaml files — HA Supervisor pulls the correct arch from the manifest automatically

## Test plan
- [ ] Merge to dev → verify `merge-dev` job creates manifest with all 4 arches (`docker buildx imagetools inspect` step in workflow logs)
- [ ] Verify dev add-on installs correctly on HA
- [ ] Merge to main → verify `merge` job creates manifest with version tag
- [ ] After verified, delete old per-arch GHCR packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)