### PR TITLE
Skip CI builds for doc-only changes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,9 +7,21 @@ on:
       - dev
     tags:
       - "v*"
+    paths-ignore:
+      - "**.md"
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/FUNDING.yml"
+      - "repository.json"
+      - "LICENSE"
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - "**.md"
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/FUNDING.yml"
+      - "repository.json"
+      - "LICENSE"
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
## Summary
- Adds `paths-ignore` filters to both `push` and `pull_request` triggers in the build workflow
- Doc-only edits (markdown, issue templates, FUNDING.yml, repository.json, LICENSE) no longer trigger full multi-arch Docker builds
- All source, Docker, and config.yaml changes still trigger builds as before

## Test plan
- [ ] Merge this PR — confirm the merge itself doesn't trigger a build (since only the workflow file changed, and `.github/workflows/build.yaml` is not in the ignore list... actually it will trigger a build this one time since the workflow file is build-relevant)
- [ ] After merge, make a README-only commit on main → confirm no workflow run
- [ ] Make a source change on dev → confirm dev build still triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)