### PR TITLE
Build stable images only on tag push

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,7 +3,6 @@ name: Build and Publish
 on:
   push:
     branches:
-      - main
       - dev
     tags:
       - "v*"


### PR DESCRIPTION
## Summary
- Removes `main` from push branch triggers so merging a PR to main no longer builds a stable image
- Only publishing a GitHub release (creating a `v*` tag) triggers the stable build
- PR validation builds (`pull_request` on `main`) and dev builds (`push` on `dev`) are unchanged

## Why
Merging PR #120 built and pushed the `1.0.1` image before the release was published. This change ensures artifact immutability — the release publication is the single gate for stable image creation.

## New release workflow
1. Create draft GitHub release with `v*` tag targeting `main`
2. PR dev → main (with version bump) — CI validates the build but doesn't push
3. Merge the PR — nothing builds
4. Publish the draft release — tag push triggers the stable build

🤖 Generated with [Claude Code](https://claude.com/claude-code)