### PR TITLE
Fix dedup cache cleared too early on discovery stop

### DIFF
--- a/src/bt_audio_manager/bluez/adapter.py
+++ b/src/bt_audio_manager/bluez/adapter.py
@@ -123,7 +123,6 @@ class BluezAdapter:
                 raise
         finally:
             self._discovering = False
-            self._rejected_log_cache.clear()
         logger.info("Device discovery stopped")
 
     async def get_audio_devices(self) -> list[dict]:


### PR DESCRIPTION
## Summary
- The `_rejected_log_cache` was cleared in `stop_discovery()`, causing the final `get_audio_devices()` call (post-stop broadcast) to re-dump all rejected devices at INFO
- Now the cache is only cleared on `start_discovery()`, so rejections are logged once per scan session and the post-stop call stays quiet

## Context
Follow-up to PR #127. Discovered during live testing that every discovery stop produced a wall of ~30+ duplicate "Skipping device" lines because the cache was emptied right before the final broadcast.

## Test plan
- [ ] Run a scan, confirm per-device rejections logged once during scan
- [ ] Confirm no re-dump of rejections after "Device discovery stopped" line
- [ ] Start a second scan, confirm cache resets and new devices are logged fresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)