### PR TITLE
Only log scan summary after discovery stops

### DIFF
--- a/src/bt_audio_manager/bluez/adapter.py
+++ b/src/bt_audio_manager/bluez/adapter.py
@@ -218,11 +218,12 @@ class BluezAdapter:
                 }
             )
 
-        logger.info(
-            "get_audio_devices: %d BlueZ objects scanned, "
-            "%d unsupported devices skipped, %d supported audio devices returned",
-            len(objects), skipped, len(devices),
-        )
+        if not self._discovering:
+            logger.info(
+                "get_audio_devices: %d BlueZ objects scanned, "
+                "%d unsupported devices skipped, %d supported audio devices returned",
+                len(objects), skipped, len(devices),
+            )
         return devices
 
     async def remove_device(self, device_path: str) -> None:


### PR DESCRIPTION
## Summary
- Suppress the repeated `get_audio_devices` summary line during active scanning — counts change on every debounced broadcast and are just noise
- Summary now only appears after discovery stops or on non-scan calls (UI load, WS connect)

## Context
Follow-up to PRs #127 and #129. During live testing, the summary was firing on every 1-second debounced broadcast during scanning, producing repetitive lines like:
```
get_audio_devices: 15 BlueZ objects scanned, 13 unsupported devices skipped, 0 supported...
get_audio_devices: 17 BlueZ objects scanned, 15 unsupported devices skipped, 0 supported...
get_audio_devices: 19 BlueZ objects scanned, 17 unsupported devices skipped, 0 supported...
```

Now only the final post-stop summary appears.

## Test plan
- [ ] Run a scan, confirm no summary lines during active scanning
- [ ] Confirm summary appears once after "Device discovery stopped"
- [ ] Confirm summary still appears on UI load / WS reconnect (non-scan context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)