### PR TITLE
Add diagnostic logging for device discovery

### DIFF
--- a/src/bt_audio_manager/bluez/constants.py
+++ b/src/bt_audio_manager/bluez/constants.py
@@ -55,3 +55,31 @@ SINK_UUIDS = frozenset({A2DP_SINK_UUID, HFP_UUID, HSP_UUID})
 # Feature flag: HFP profile switching is disabled until the HAOS audio
 # container supports SCO sockets (AF_BLUETOOTH).  See issue #98.
 HFP_SWITCHING_ENABLED = False
+
+# ── Bluetooth Class of Device (CoD) helpers ──────────────────────────
+# The 24-bit CoD field encodes Major Device Class in bits 12-8.
+# See Bluetooth Assigned Numbers § 2.8.
+COD_MAJOR_AUDIO = 0x04
+
+_COD_MAJOR_LABELS = {
+    0x00: "Misc",
+    0x01: "Computer",
+    0x02: "Phone",
+    0x03: "LAN/AP",
+    COD_MAJOR_AUDIO: "Audio/Video",
+    0x05: "Peripheral",
+    0x06: "Imaging",
+    0x07: "Wearable",
+    0x08: "Toy",
+    0x09: "Health",
+}
+
+
+def cod_major_class(cod: int) -> int:
+    """Extract Major Device Class from a raw CoD value (bits 12-8)."""
+    return (cod >> 8) & 0x1F
+
+
+def cod_major_label(cod: int) -> str:
+    """Return a human-readable label for the Major Device Class."""
+    return _COD_MAJOR_LABELS.get(cod_major_class(cod), "Unknown")


### PR DESCRIPTION
## Summary
- Broadened discovery to all transports (BR/EDR + BLE) with no UUID filter so BlueZ reports every nearby device
- Log every rejected device at INFO with clear reason (LE Audio, source-only, AVRCP-only, no UUIDs, no audio sink)
- Added Bluetooth Class of Device (CoD) to discovery and rejection logs to identify audio-class hardware that advertises no UUIDs (budget devices / not in pairing mode)
- Scan summary now reports supported/unsupported counts with a separate count for audio-class devices with no UUIDs
- Fixed dedup cache being cleared too early on discovery stop (causing duplicate rejection logs)

## Test plan
- [ ] Deploy dev build and run a scan with nearby BT devices
- [ ] Verify discovery log lines include CoD, AddressType, and Appearance fields
- [ ] Verify rejection log lines include CoD field
- [ ] Verify scan summary shows separate audio-class-no-UUID count when applicable
- [ ] Confirm no filter behavior changes — same devices accepted/rejected as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)