### PR TITLE
Show device state in accepted discovery log

### DIFF
--- a/src/bt_audio_manager/bluez/adapter.py
+++ b/src/bt_audio_manager/bluez/adapter.py
@@ -200,9 +200,15 @@ class BluezAdapter:
                     f"0x{cod_raw:06X}({cod_major_label(cod_raw)})"
                     if cod_raw else "(none)"
                 )
+                if connected:
+                    state = "connected"
+                elif paired:
+                    state = "paired (offline)"
+                else:
+                    state = "unpaired"
                 logger.info(
-                    "Accepted device %s (%s) — matched %s. CoD: %s",
-                    name, addr, matched, cod_str,
+                    "Accepted device %s (%s) [%s] — matched %s. CoD: %s",
+                    name, addr, state, matched, cod_str,
                 )
 
             # Detect active bearers (BR/EDR vs LE)
@@ -257,7 +263,7 @@ class BluezAdapter:
                 parts.append(
                     f"{audio_class_no_uuid} audio-class device(s) with no UUIDs skipped"
                 )
-            parts.append(f"{len(devices)} supported audio devices returned")
+            parts.append(f"{len(devices)} supported audio devices matched")
             logger.info("get_audio_devices: %s", ", ".join(parts))
         return devices
 


### PR DESCRIPTION
## Summary
- Accepted devices now log their state: `[connected]`, `[paired (offline)]`, or `[unpaired]` so cached BlueZ entries (like the powered-off Bose) are distinguishable from live devices
- Changed summary wording from "returned" to "matched" to avoid implying the device responded to the scan

Example output:
```
Accepted device Jabra SPEAK 510 USB (50:1A:A5:79:88:15) [connected] — matched [...]. CoD: 0x240404(Audio/Video)
Accepted device Bose Micro SoundLink (2C:41:A1:ED:84:29) [paired (offline)] — matched [...]. CoD: 0x240414(Audio/Video)
```

## Test plan
- [ ] Run scan with a mix of connected, paired-but-off, and unpaired audio devices
- [ ] Verify correct state labels in the accepted log lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)