### PR TITLE
Raise max scan duration from 60s to 120s

### DIFF
--- a/src/bt_audio_manager/web/api.py
+++ b/src/bt_audio_manager/web/api.py
@@ -436,8 +436,8 @@ def create_api_routes(
                 errors.append("reconnect_max_backoff_seconds must be an integer between 60 and 3600")
         if "scan_duration_seconds" in body:
             v = body["scan_duration_seconds"]
-            if not isinstance(v, int) or v < 5 or v > 60:
-                errors.append("scan_duration_seconds must be an integer between 5 and 60")
+            if not isinstance(v, int) or v < 5 or v > 120:
+                errors.append("scan_duration_seconds must be an integer between 5 and 120")
 
         if errors:
             return web.json_response({"error": "; ".join(errors)}, status=400)

--- a/src/bt_audio_manager/web/static/index.html
+++ b/src/bt_audio_manager/web/static/index.html
@@ -247,7 +247,7 @@
           <!-- Device Discovery -->
           <div class="mb-3">
             <label for="setting-scan-duration" class="form-label">Scan Duration (seconds)</label>
-            <input type="number" class="form-control" id="setting-scan-duration" min="5" max="60" step="1">
+            <input type="number" class="form-control" id="setting-scan-duration" min="5" max="120" step="1">
             <div class="form-text">
               How long to scan for discoverable Bluetooth audio devices (5&ndash;60).
             </div>


### PR DESCRIPTION
## Summary
- Raises the maximum configurable scan duration from 60s to 120s (default stays at 30s)
- Dual-mode BR/EDR devices can take 60-90s for full UUID resolution; users who encounter this can now increase their scan time

## Test plan
- [ ] Verify settings UI allows values up to 120
- [ ] Verify API rejects values above 120
- [ ] Confirm default remains 30s for new installs

🤖 Generated with [Claude Code](https://claude.com/claude-code)