### PR TITLE
Add bug/feature issue templates and auto-link device issues to megathread

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,95 @@
+name: Bug Report
+description: Report a general add-on bug — not for device-specific issues
+title: "[bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for **general add-on bugs** — UI issues, crashes, settings problems, etc.
+        If your issue is with a **specific Bluetooth device** (discovery, pairing, connection), use the **Device Discovery / Pairing Issue** template instead.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug description
+      description: What is broken?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: How can we trigger this bug?
+      value: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What happens instead?
+    validations:
+      required: true
+
+  - type: input
+    id: haos-version
+    attributes:
+      label: HAOS version
+      placeholder: e.g. 14.1
+    validations:
+      required: true
+
+  - type: input
+    id: addon-version
+    attributes:
+      label: App version
+      placeholder: e.g. 0.3.5
+    validations:
+      required: true
+
+  - type: input
+    id: hardware
+    attributes:
+      label: Hardware
+      placeholder: e.g. RPi 4, Home Assistant Green, Yellow, x86 NUC
+    validations:
+      required: true
+
+  - type: dropdown
+    id: access-method
+    attributes:
+      label: Access method
+      options:
+        - Ingress
+        - Direct URL
+        - Both
+        - N/A
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Paste relevant add-on logs here. Go to Settings → Add-ons → Bluetooth Audio Manager → Log tab.
+      render: text
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Screenshots, configuration details, or anything else that might help.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,8 @@
 blank_issues_enabled: false
+contact_links:
+  - name: Device Issues Megathread
+    url: https://github.com/scyto/ha-bluetooth-audio-manager/issues/39
+    about: Browse known device issues or add yours as a sub-issue to the megathread
+  - name: Questions & Discussion
+    url: https://github.com/scyto/ha-bluetooth-audio-manager/discussions
+    about: Ask questions, share ideas, or chat with the community

--- a/.github/ISSUE_TEMPLATE/device-issue.yml
+++ b/.github/ISSUE_TEMPLATE/device-issue.yml
@@ -1,13 +1,17 @@
-name: Device Issue Report
-description: Report a device-specific issue or oddity
+name: Device Discovery / Pairing Issue
+description: Report a problem with Bluetooth device discovery, pairing, or connection — not for general add-on bugs
 title: "Device: "
-labels: ["device-issue"]
+labels: ["Device Issue"]
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for reporting a device issue. Please fill in the details below. Please be sure to attach full logs.
-        Check the [Device Issues Megathread](https://github.com/scyto/ha-bluetooth-audio-manager/issues/39) first to see if your device is already listed.
+        This template is for issues with a **specific Bluetooth device** — discovery, pairing, connection, audio playback, or stability.
+        For general add-on bugs (UI, settings, crashes) use the **Bug Report** template instead.
+
+        **Before opening an issue:**
+        Check the [Device Issues Megathread](https://github.com/scyto/ha-bluetooth-audio-manager/issues/39) to see if your device is already listed.
+        Please attach **full logs** — issues without logs may be closed.
 
   - type: input
     id: device-name
@@ -67,6 +71,7 @@ body:
     attributes:
       label: Diagnostics
       options:
+        - label: Device is discovered
         - label: Pairing succeeds
         - label: Audio plays
         - label: Disconnects frequently
@@ -85,3 +90,12 @@ body:
     attributes:
       label: Workaround
       description: Any workaround found, or "None known"
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: Paste full add-on logs here. Go to Settings → Add-ons → Bluetooth Audio Manager → Log tab.
+      render: text
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,37 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+title: "[enhancement] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have an idea for the add-on? Describe it below.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Feature description
+      description: What would you like to see added or changed?
+    validations:
+      required: true
+
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use case / motivation
+      description: Why is this feature useful? What problem does it solve?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Have you considered any workarounds or alternative approaches?
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Mockups, screenshots, links, or any other relevant information.

--- a/.github/workflows/link-device-issues.yaml
+++ b/.github/workflows/link-device-issues.yaml
@@ -1,0 +1,27 @@
+name: Link Device Issues to Megathread
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  link-to-megathread:
+    if: contains(github.event.issue.labels.*.name, 'Device Issue')
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Add as sub-issue of megathread (#39)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api graphql -f query='
+            mutation {
+              addSubIssue(input: {
+                issueId: "I_kwDORMlHL87qJGEO",
+                subIssueId: "${{ github.event.issue.node_id }}"
+              }) {
+                issue { id }
+                subIssue { id }
+              }
+            }'


### PR DESCRIPTION
## Summary
Cherry-pick of bd7b253 from dev → main so issue templates are live immediately.

- **Device template** renamed to "Device Discovery / Pairing Issue" with clarified scope, fixed label, added "Device is discovered" checkbox, and required logs field
- **Bug report template** added with `[bug]` title prefix
- **Feature request template** added with `[enhancement]` title prefix
- **Auto-link workflow** — new GitHub Action adds device issues as sub-issues of the megathread (#39)
- **Template chooser** — added contact links for the Device Issues Megathread and Discussions

## Test plan
- [ ] Visit the [template chooser](https://github.com/scyto/ha-bluetooth-audio-manager/issues/new/choose) and verify all 3 templates + 2 contact links appear
- [ ] Click each template and confirm fields render with correct title prefixes
- [ ] Create a test device issue to verify the auto-link workflow attaches it to #39, then close/delete it

🤖 Generated with [Claude Code](https://claude.com/claude-code)