### PR TITLE
Fix device template diagnostics to focus on problems

### DIFF
--- a/.github/ISSUE_TEMPLATE/device-issue.yml
+++ b/.github/ISSUE_TEMPLATE/device-issue.yml
@@ -69,13 +69,14 @@ body:
   - type: checkboxes
     id: diagnostics
     attributes:
-      label: Diagnostics
+      label: What doesn't work (check all that apply)
       options:
-        - label: Device is discovered
-        - label: Pairing succeeds
-        - label: Audio plays
+        - label: Device is not discovered
+        - label: Pairing fails
+        - label: No audio after pairing
         - label: Disconnects frequently
-        - label: Reconnect works
+        - label: Device buttons kill connection
+        - label: Reconnect fails
 
   - type: textarea
     id: issue


### PR DESCRIPTION
## Summary
- Replace mixed works/doesn't-work diagnostics checklist with a clear "What doesn't work" list — checked items now consistently mean problems
- Add "Device buttons kill connection" option

## Test plan
- [ ] Visit the [device template](https://github.com/scyto/ha-bluetooth-audio-manager/issues/new?template=device-issue.yml) and verify the checklist reads clearly

🤖 Generated with [Claude Code](https://claude.com/claude-code)