### PR TITLE
Add Claude Code GitHub Action for PR reviews

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,24 @@
+name: Claude Code
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  claude:
+    if: |
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    steps:
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary
- Adds `claude.yml` workflow for automated PR code reviews
- Triggers on PR open/sync (auto-review) and `@claude` mentions in comments
- Requires `ANTHROPIC_API_KEY` repository secret to be configured

## Setup required
Add your `ANTHROPIC_API_KEY` as a repository secret:  
**Settings → Secrets and variables → Actions → New repository secret**

## Test plan
- [ ] Add `ANTHROPIC_API_KEY` repo secret
- [ ] Merge this PR to main
- [ ] Open a test PR and verify Claude posts a review
- [ ] Comment `@claude` on a PR and verify it responds

🤖 Generated with [Claude Code](https://claude.com/claude-code)