### PR TITLE
Fix out-of-order logs in HA log viewer

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -45,7 +45,8 @@ ARG BUILD_DATE
 ARG BUILD_VERSION
 ARG BUILD_SHA=""
 ENV BUILD_VERSION="${BUILD_VERSION}" \
-    BUILD_SHA="${BUILD_SHA}"
+    BUILD_SHA="${BUILD_SHA}" \
+    PYTHONUNBUFFERED="1"
 LABEL \
     io.hass.name="Bluetooth Audio Manager" \
     io.hass.type="addon" \


### PR DESCRIPTION
## Summary
- Adds `PYTHONUNBUFFERED=1` to the Dockerfile so Python flushes stdout immediately
- Without this, Python block-buffers stdout (~8KB) in Docker containers (no TTY), causing startup logs to appear seconds late and out of chronological order in the HA Supervisor log viewer

## Test plan
- [ ] Rebuild and restart the add-on
- [ ] Verify log lines in the HA Supervisor log viewer appear in strict chronological order (startup logs should no longer appear after later messages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)