### PR TITLE
Tie MPD log verbosity to app log level

### DIFF
--- a/src/bt_audio_manager/audio/mpd.py
+++ b/src/bt_audio_manager/audio/mpd.py
@@ -52,11 +52,16 @@ class MPDManager:
         port: int,
         speaker_name: str,
         password: str | None = None,
+        log_level: str = "info",
     ) -> None:
         self._address = address
         self._port = port
         self._speaker_name = speaker_name
         self._password = password
+        # Map app log level to MPD log level:
+        # debug → "verbose" (full client/command chatter)
+        # anything else → "default" (errors/warnings only)
+        self._mpd_log_level = "verbose" if log_level == "debug" else "default"
 
         # Per-instance paths (port as discriminator)
         self._instance_dir = f"{MPD_BASE_DIR}/instance_{port}"
@@ -143,7 +148,7 @@ class MPDManager:
             pid_file            "{pid_file}"
             bind_to_address     "0.0.0.0"
             port                "{port}"
-            log_level           "verbose"
+            log_level           "{mpd_log_level}"
             auto_update         "no"
             {password_line}
 
@@ -166,6 +171,7 @@ class MPDManager:
             password_line=password_line,
             speaker_name=self._speaker_name.replace("\\", "\\\\").replace('"', '\\"'),
             sink=self._sink_name.replace("\\", "\\\\").replace('"', '\\"'),
+            mpd_log_level=self._mpd_log_level,
         )
 
         with open(self._conf_path, "w") as f:

--- a/src/bt_audio_manager/manager.py
+++ b/src/bt_audio_manager/manager.py
@@ -2755,6 +2755,7 @@ class BluetoothAudioManager:
             port=port,
             speaker_name=mpd_name,
             password=mpd_password,
+            log_level=self.config.log_level,
         )
         try:
             await mpd.start(sink_name)


### PR DESCRIPTION
## Summary
- HA's built-in MPD integration polls `status` + `currentsong` every ~10s, generating 6 noisy INFO lines per poll per MPD instance
- Maps the add-on's `log_level` to MPD's own `log_level`: `debug` → `"verbose"` (full output), anything else → `"default"` (errors/warnings only)
- Client connection chatter now only appears when the add-on is set to debug

## Test plan
- [ ] Set add-on log level to `info` → connect a speaker with MPD enabled → verify no `client:` chatter in logs
- [ ] Set add-on log level to `debug` → verify verbose MPD output (client connections, commands) appears
- [ ] Verify MPD errors (e.g. bad sink name) still appear at `info` level

🤖 Generated with [Claude Code](https://claude.com/claude-code)