### PR TITLE
Fix MPD queue not advancing to next track

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,15 +1,17 @@
 ARG BUILD_FROM=ghcr.io/home-assistant/amd64-base:3.20
 FROM ${BUILD_FROM}
 
-# Pull bluez packages from Alpine edge (newer than base 3.20)
+# Pull bluez and mpd from Alpine edge (newer than base 3.20)
 RUN apk add --no-cache \
     --repository=https://dl-cdn.alpinelinux.org/alpine/edge/main \
     bluez \
     bluez-btmon \
     bluez-libs \
     && apk add --no-cache \
-    dbus-libs \
+    --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community \
     mpd \
+    && apk add --no-cache \
+    dbus-libs \
     pulseaudio-utils \
     python3 \
     py3-pip

--- a/src/bt_audio_manager/audio/mpd.py
+++ b/src/bt_audio_manager/audio/mpd.py
@@ -97,6 +97,7 @@ class MPDManager:
         self._generate_config()
         await self._start_daemon()
         await self._connect_client()
+        await self._reset_playback_modes()
         self._running = True
         logger.info("MPD started for %s on port %d", self._address, self._port)
 
@@ -131,6 +132,26 @@ class MPDManager:
     @property
     def address(self) -> str:
         return self._address
+
+    async def _reset_playback_modes(self) -> None:
+        """Reset MPD playback modes to defaults for queue advancement.
+
+        HA's media player (or other clients) may set single/consume/repeat/
+        random, and these persist in the state file across restarts.  Reset
+        them so the queue always advances normally.
+        """
+        if not self._client:
+            return
+        try:
+            await self._client.single(0)
+            await self._client.consume(0)
+            await self._client.repeat(0)
+            await self._client.random(0)
+        except Exception as e:
+            logger.warning(
+                "Failed to reset MPD playback modes (port %d): %s",
+                self._port, e,
+            )
 
     # -- Config generation --
 


### PR DESCRIPTION
## Summary
- **Reset playback modes on startup**: Clears stale `single`/`consume`/`repeat`/`random` state persisted in MPD's state file. The `single` mode (set by HA's media player or other clients) was surviving restarts and preventing queue advancement.
- **Upgrade MPD from 0.23.15 to 0.24.x**: Pulls MPD from Alpine edge/community. Fixes upstream bugs: stalled playback after queue modification, deadlock with single mode, and resuming playback after single-mode pause on PulseAudio outputs (0.24.2–0.24.5).

## Test plan
- [ ] Connect a Bluetooth speaker
- [ ] Queue multiple tracks in HA's media player
- [ ] Verify the queue advances automatically after each track finishes
- [ ] Verify `mpc -p <port> status` shows `single: off`
- [ ] Toggle repeat/shuffle in HA UI and confirm they work during the session

🤖 Generated with [Claude Code](https://claude.com/claude-code)