### PR TITLE
Strip MPD to minimal streaming config

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,8 +30,7 @@ RUN chmod +x /init \
     && chmod +x /etc/s6-overlay/s6-rc.d/bt-audio-manager/run \
     && chmod +x /etc/s6-overlay/s6-rc.d/bt-audio-manager/finish \
     && chmod +x /etc/cont-init.d/01-verify-dbus.sh \
-    && chmod +x /etc/cont-init.d/02-init-storage.sh \
-    && chmod +x /etc/cont-init.d/03-init-mpd.sh
+    && chmod +x /etc/cont-init.d/02-init-storage.sh
 
 ENV PYTHONPATH="/usr/src"
 

--- a/docker/rootfs/etc/cont-init.d/03-init-mpd.sh
+++ b/docker/rootfs/etc/cont-init.d/03-init-mpd.sh
@@ -1,9 +1,0 @@
-#!/command/with-contenv bashio
-# shellcheck shell=bash
-# ==============================================================================
-# Initialize MPD directories
-# ==============================================================================
-
-mkdir -p /data/mpd/music /data/mpd/playlists
-
-bashio::log.info "MPD directories initialized."


### PR DESCRIPTION
## Summary
- Remove `music_directory`, `playlist_directory`, `db_file` from MPD config — HA's MPD integration sends URLs via `client.add(url)` which MPD streams through the curl input plugin; no local files are ever stored
- Remove `/data/mpd/` directory creation and all persistent storage — eliminates the `Permission denied` database write error
- Delete `03-init-mpd.sh` container init script (was only creating those dirs)

MPD config is now just: PulseAudio output + curl input + bind/port/pid.

## Test plan
- [ ] CI build passes
- [ ] Connect speaker, play media from HA media player → audio plays
- [ ] No `Permission denied` or `/data/mpd` errors in logs
- [ ] Queue multiple tracks, verify advancement works

🤖 Generated with [Claude Code](https://claude.com/claude-code)