### PR TITLE
Remove Alpine default mpd.conf to prevent privilege dropping

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,6 +9,7 @@ RUN apk add --no-cache \
     bluez-btmon \
     bluez-libs \
     mpd \
+    && rm -f /etc/mpd.conf \
     && apk add --no-cache \
     dbus-libs \
     pulseaudio-utils \


### PR DESCRIPTION
## Summary
- Delete `/etc/mpd.conf` after installing the mpd package in the Dockerfile
- Alpine's mpd package ships a default config with `user "mpd"` which causes MPD to drop privileges from root to the mpd user, resulting in "Permission denied" when writing the database to `/tmp`
- We generate our own per-instance config, so the system config is unnecessary and actively harmful

## Test plan
- [ ] CI build passes
- [ ] Connect speaker, play media → audio plays
- [ ] No "Permission denied" errors in MPD logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)