### PR TITLE
Remove db_file from MPD config to eliminate database errors

### DIFF
--- a/src/bt_audio_manager/audio/mpd.py
+++ b/src/bt_audio_manager/audio/mpd.py
@@ -118,12 +118,10 @@ class MPDManager:
         config = textwrap.dedent("""\
             music_directory     "{tmp_dir}/music"
             playlist_directory  "{tmp_dir}/playlists"
-            db_file             "{tmp_dir}/database"
             pid_file            "{pid_file}"
             bind_to_address     "0.0.0.0"
             port                "{port}"
             log_level           "{mpd_log_level}"
-            auto_update         "no"
             {password_line}
 
             audio_output {{


### PR DESCRIPTION
## Summary
- Remove `db_file` and `auto_update` from the generated MPD config
- The database is unused — HA streams URLs via `client.add(url)` which bypasses the database entirely
- Eliminates `Failed to open/save database` errors on MPD startup

`music_directory` and `playlist_directory` are kept to avoid other MPD warnings.

## Test plan
- [ ] Deploy and verify no `Failed to open ... database` or `Failed to save database` errors in MPD logs
- [ ] Verify MPD still accepts and plays URLs via HA's MPD integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)