### PR TITLE
Add state_file to MPD config to fix lock permission error

### DIFF
--- a/src/bt_audio_manager/audio/mpd.py
+++ b/src/bt_audio_manager/audio/mpd.py
@@ -118,6 +118,7 @@ class MPDManager:
         config = textwrap.dedent("""\
             music_directory     "{tmp_dir}/music"
             playlist_directory  "{tmp_dir}/playlists"
+            state_file          "{tmp_dir}/state"
             pid_file            "{pid_file}"
             bind_to_address     "0.0.0.0"
             port                "{port}"


### PR DESCRIPTION
## Summary
- Add explicit `state_file` pointing to `/tmp/mpd_{port}/state`
- Without it, MPD falls back to an XDG default path that isn't writable, causing `lock: Permission denied`

## Test plan
- [ ] Deploy and verify no `lock: Permission denied` in MPD logs
- [ ] Verify MPD starts and plays audio normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)