### PR TITLE
Fix CI race condition in dev version update job

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -351,12 +351,12 @@ jobs:
           fi
 
           # Close any stale dev-version PRs
-          gh pr list --head "chore/dev-version-" --state open --json number --jq '.[].number' | \
+          gh pr list --state open --json number,headRefName --jq '.[] | select(.headRefName | startswith("chore/dev-version-")) | .number' | \
             xargs -I {} gh pr close {} --delete-branch 2>/dev/null || true
 
           git checkout -b "$BRANCH"
           git commit -m "chore: update dev app version to sha-${SHORT_SHA}"
-          git push origin "$BRANCH"
+          git push --force origin "$BRANCH"
 
           gh pr create \
             --base main \


### PR DESCRIPTION
## Summary
- **Force-push** the ephemeral version branch to handle stale branches from previous runs
- **Fix stale PR cleanup** — `gh pr list --head` requires exact match, so `--head "chore/dev-version-"` never matched anything. Now uses `jq` with `startswith()` for proper prefix matching.

Fixes the `! [rejected] ... (fetch first)` error when merging multiple PRs to dev quickly.

## Test plan
- [ ] Merge this PR, then merge another PR to dev quickly after — the version update job should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)