### PR TITLE
Explicitly run MPD as root to fix database permission errors

### DIFF
--- a/src/bt_audio_manager/audio/mpd.py
+++ b/src/bt_audio_manager/audio/mpd.py
@@ -119,6 +119,7 @@ class MPDManager:
             password_line = f'password "{self._password}@read,add,control,admin"'
 
         config = textwrap.dedent("""\
+            user                "root"
             music_directory     "{tmp_dir}/music"
             playlist_directory  "{tmp_dir}/playlists"
             db_file             "{db_file}"


### PR DESCRIPTION
## Summary
- Add `user "root"` to the generated MPD config
- Despite removing `/etc/mpd.conf` (PR #180), MPD still drops privileges — likely a compiled-in default in Alpine's MPD package
- This causes "Failed to commit database: Permission denied" on both `/tmp` and `/data` paths
- Explicit `user "root"` prevents privilege dropping entirely

## Test plan
- [ ] Deploy and verify no `Failed to commit database: Permission denied` errors
- [ ] Verify no `lock: Permission denied` errors
- [ ] The `Failed to open database/state: No such file or directory` messages on first boot are expected (files don't exist yet) and should not recur after first save

🤖 Generated with [Claude Code](https://claude.com/claude-code)