### PR TITLE
Chown MPD dirs to mpd user to fix permission errors

### DIFF
--- a/src/bt_audio_manager/audio/mpd.py
+++ b/src/bt_audio_manager/audio/mpd.py
@@ -11,6 +11,7 @@ media_player entity per speaker.
 import asyncio
 import logging
 import os
+import shutil
 import textwrap
 
 from mpd.asyncio import MPDClient
@@ -72,6 +73,12 @@ class MPDManager:
         os.makedirs(f"{self._tmp_dir}/music", exist_ok=True)
         os.makedirs(f"{self._tmp_dir}/playlists", exist_ok=True)
         os.makedirs(self._data_dir, exist_ok=True)
+        # MPD drops privileges to the 'mpd' user (Alpine package default).
+        # Chown all dirs so the dropped-privilege process can write.
+        for d in (self._tmp_dir, self._data_dir):
+            shutil.chown(d, user="mpd", group="mpd")
+        for sub in ("music", "playlists"):
+            shutil.chown(f"{self._tmp_dir}/{sub}", user="mpd", group="mpd")
         self._generate_config()
         await self._start_daemon()
         await self._connect_client()
@@ -119,7 +126,6 @@ class MPDManager:
             password_line = f'password "{self._password}@read,add,control,admin"'
 
         config = textwrap.dedent("""\
-            user                "root"
             music_directory     "{tmp_dir}/music"
             playlist_directory  "{tmp_dir}/playlists"
             db_file             "{db_file}"


### PR DESCRIPTION
## Summary
- **Chown** all MPD directories (`/tmp/mpd_{port}/`, `/data/mpd/{port}/`, and subdirs) to `mpd:mpd` before starting the daemon
- Alpine's MPD package drops privileges to the `mpd` user on start — our root-owned dirs are unwritable after the drop
- **Removes `user "root"`** from config which crashed MPD with `no such user "root"` (HA container issue)

## Root cause
Alpine's MPD binary drops privileges to the `mpd` user (created by the package). Our Python process creates directories as root. After privilege drop, MPD can't write to root-owned dirs → `Permission denied` on database commit, lock, and state file.

## Test plan
- [ ] No `Permission denied` or `lock` errors in MPD logs
- [ ] No `no such user` errors
- [ ] MPD starts, connects client, plays audio normally
- [ ] First-boot `Failed to open database/state: No such file or directory` is expected (MPD creates the files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)