### PR TITLE
Prefer stored BR/EDR name over live BlueZ name

### DIFF
--- a/src/bt_audio_manager/manager.py
+++ b/src/bt_audio_manager/manager.py
@@ -1153,6 +1153,9 @@ class BluetoothAudioManager:
             addr = device["address"]
             device["stored"] = addr in stored_addresses
             if device["stored"]:
+                stored_entry = self.store.get_device(addr)
+                if stored_entry and stored_entry.get("name"):
+                    device["name"] = stored_entry["name"]
                 s = self.store.get_device_settings(addr)
                 device["idle_mode"] = s.get("idle_mode", "default")
                 device["keep_alive_method"] = s["keep_alive_method"]


### PR DESCRIPTION
## Summary
- For paired/stored devices, use the name captured at pair time (BR/EDR connection) instead of the live BlueZ `Name` property
- Fixes dual-mode devices (e.g. Bose Micro SoundLink) showing LE advertisement name ("LE-Bose Micro SoundLink") in the UI after LE advertisements overwrite BlueZ's `Name` property

## Test plan
- [ ] Pair a dual-mode Bluetooth speaker and verify the UI always shows the BR/EDR name
- [ ] Confirm LE `PropertiesChanged` name updates still appear in logs but don't affect the displayed name
- [ ] Verify offline stored devices still display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)