### PR TITLE
Fix AppArmor missing flock permission and strip unused MPD database

### DIFF
--- a/bluetooth_audio_manager/apparmor.txt
+++ b/bluetooth_audio_manager/apparmor.txt
@@ -40,12 +40,12 @@ profile bluetooth_audio_manager flags=(attach_disconnected,mediate_deleted) {
   /root/.config/pulse/ rw,
   /root/.config/pulse/** rw,
 
-  # Persistent data storage
-  /data/** rw,
+  # Persistent data storage (k = flock, needed by MPD state/database)
+  /data/** rwk,
   /data/ r,
 
-  # Temporary files
-  /tmp/** rw,
+  # Temporary files (k = flock, needed by MPD state/database)
+  /tmp/** rwk,
 
   # Python runtime
   /usr/lib/python3*/** r,

--- a/bluetooth_audio_manager_dev/apparmor.txt
+++ b/bluetooth_audio_manager_dev/apparmor.txt
@@ -40,12 +40,12 @@ profile bluetooth_audio_manager flags=(attach_disconnected,mediate_deleted) {
   /root/.config/pulse/ rw,
   /root/.config/pulse/** rw,
 
-  # Persistent data storage
-  /data/** rw,
+  # Persistent data storage (k = flock, needed by MPD state/database)
+  /data/** rwk,
   /data/ r,
 
-  # Temporary files
-  /tmp/** rw,
+  # Temporary files (k = flock, needed by MPD state/database)
+  /tmp/** rwk,
 
   # Python runtime
   /usr/lib/python3*/** r,


### PR DESCRIPTION
## Summary

**Root cause found**: AppArmor profile had `/data/** rw` and `/tmp/** rw` but was missing `k` (flock/lock permission). This blocked MPD's `flock()` and `linkat()` syscalls, causing all the "Permission denied" errors — regardless of filesystem permissions (chmod 777 was irrelevant).

### Changes
- **AppArmor**: Add `k` to `/data/**` and `/tmp/**` rules → `rwk`
- **MPD config**: Strip `music_directory`, `playlist_directory`, `db_file` — unused since HA streams URLs via `client.add(url)`. Avoids the O_TMPFILE/linkat() issue entirely.
- **Cleanup**: Remove chmod/makedirs for directories that no longer exist

## Test plan
- [ ] No `Permission denied` errors in MPD logs
- [ ] No `lock: Permission denied` errors
- [ ] No `Failed to commit database` errors
- [ ] `Failed to open state: No such file or directory` on first boot only (harmless)
- [ ] MPD starts and plays audio via HA integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)