### PR TITLE
Add flock (k) permission to AppArmor profile for MPD

### DIFF
--- a/bluetooth_audio_manager/apparmor.txt
+++ b/bluetooth_audio_manager/apparmor.txt
@@ -40,12 +40,12 @@ profile bluetooth_audio_manager flags=(attach_disconnected,mediate_deleted) {
   /root/.config/pulse/ rw,
   /root/.config/pulse/** rw,
 
-  # Persistent data storage
-  /data/** rw,
+  # Persistent data storage (k = flock, needed by MPD state/database)
+  /data/** rwk,
   /data/ r,
 
-  # Temporary files
-  /tmp/** rw,
+  # Temporary files (k = flock, needed by MPD state/database)
+  /tmp/** rwk,
 
   # Python runtime
   /usr/lib/python3*/** r,

--- a/bluetooth_audio_manager_dev/apparmor.txt
+++ b/bluetooth_audio_manager_dev/apparmor.txt
@@ -40,12 +40,12 @@ profile bluetooth_audio_manager flags=(attach_disconnected,mediate_deleted) {
   /root/.config/pulse/ rw,
   /root/.config/pulse/** rw,
 
-  # Persistent data storage
-  /data/** rw,
+  # Persistent data storage (k = flock, needed by MPD state/database)
+  /data/** rwk,
   /data/ r,
 
-  # Temporary files
-  /tmp/** rw,
+  # Temporary files (k = flock, needed by MPD state/database)
+  /tmp/** rwk,
 
   # Python runtime
   /usr/lib/python3*/** r,


### PR DESCRIPTION
## Summary
- Add `k` (flock/lock) to `/data/**` and `/tmp/**` AppArmor rules
- HA Supervisor reads `apparmor.txt` from main, so this needs to land here directly
- Fixes MPD "Permission denied" and "lock" errors caused by AppArmor blocking `flock()` syscalls

Companion to dev PR #197 which also strips the unused MPD database config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)