### PR TITLE
Add playlist_directory to suppress MPD warning

### DIFF
--- a/src/bt_audio_manager/audio/mpd.py
+++ b/src/bt_audio_manager/audio/mpd.py
@@ -66,7 +66,7 @@ class MPDManager:
             return
 
         self._sink_name = sink_name
-        os.makedirs(self._tmp_dir, exist_ok=True)
+        os.makedirs(f"{self._tmp_dir}/playlists", exist_ok=True)
         self._generate_config()
         await self._start_daemon()
         await self._connect_client()
@@ -114,6 +114,7 @@ class MPDManager:
             password_line = f'password "{self._password}@read,add,control,admin"'
 
         config = textwrap.dedent("""\
+            playlist_directory  "{tmp_dir}/playlists"
             state_file          "{tmp_dir}/state"
             pid_file            "{pid_file}"
             bind_to_address     "0.0.0.0"


### PR DESCRIPTION
## Summary
- Adds `playlist_directory` pointing to `/tmp/mpd_{port}/playlists` to suppress the "Stored playlists are disabled" warning that appeared after stripping the database config in #197
- Creates the directory alongside the existing `os.makedirs` for the tmp dir

## Context
After #197 stripped `music_directory`, `playlist_directory`, and `db_file` from the MPD config, MPD started logging "Stored playlists are disabled" on every startup. This restores just `playlist_directory` (the only one needed to silence the warning) without re-introducing the database.

## Remaining MPD log status after this + #198
- **"lock: Permission denied"** — fixed by AppArmor `k` permission (#198, merged on main)
- **"Stored playlists are disabled"** — fixed by this PR
- **"Failed to open state: No such file or directory"** — harmless first-boot only, MPD creates it

🤖 Generated with [Claude Code](https://claude.com/claude-code)