### PR TITLE
Pre-create empty MPD state file for first boot

### DIFF
--- a/src/bt_audio_manager/audio/mpd.py
+++ b/src/bt_audio_manager/audio/mpd.py
@@ -67,6 +67,10 @@ class MPDManager:
 
         self._sink_name = sink_name
         os.makedirs(f"{self._tmp_dir}/playlists", exist_ok=True)
+        # Pre-create empty state file so MPD doesn't warn on first boot
+        state_path = f"{self._tmp_dir}/state"
+        if not os.path.exists(state_path):
+            open(state_path, "a").close()
         self._generate_config()
         await self._start_daemon()
         await self._connect_client()


### PR DESCRIPTION
## Summary
- Touches an empty state file before launching MPD to suppress the "Failed to open state: No such file or directory" warning on first boot

## Context
After #197 moved MPD state to `/tmp/mpd_{port}/`, the state file doesn't exist on first boot (since `/tmp` is ephemeral). MPD logs a warning but creates the file itself. This pre-creates it to keep the logs clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)