### PR TITLE
Remove state_file from MPD config to fix lock/commit errors

### DIFF
--- a/src/bt_audio_manager/audio/mpd.py
+++ b/src/bt_audio_manager/audio/mpd.py
@@ -67,10 +67,6 @@ class MPDManager:
 
         self._sink_name = sink_name
         os.makedirs(f"{self._tmp_dir}/playlists", exist_ok=True)
-        # Pre-create empty state file so MPD doesn't warn on first boot
-        state_path = f"{self._tmp_dir}/state"
-        if not os.path.exists(state_path):
-            open(state_path, "a").close()
         self._generate_config()
         await self._start_daemon()
         await self._connect_client()
@@ -119,7 +115,6 @@ class MPDManager:
 
         config = textwrap.dedent("""\
             playlist_directory  "{tmp_dir}/playlists"
-            state_file          "{tmp_dir}/state"
             pid_file            "{pid_file}"
             bind_to_address     "0.0.0.0"
             port                "{port}"


### PR DESCRIPTION
## Summary
- Removes `state_file` from MPD config to eliminate `lock: Permission denied` and `Failed to commit state: Permission denied` errors
- Removes the pre-create state file code (added in #202) since it's no longer needed

## Root cause
MPD 0.24.x uses `O_TMPFILE` + `linkat(AT_EMPTY_PATH)` for atomic state writes. `linkat(AT_EMPTY_PATH)` requires `CAP_DAC_READ_SEARCH`, which isn't in the HA container's capability set. No AppArmor DENIED entries appear in dmesg — this is a Linux capability issue, not AppArmor.

Without state_file, MPD won't try to save state at all. HA's MPD integration manages the queue and playback state via the MPD protocol, so persistence is unnecessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)