### PR TITLE
Add flock permission to PulseAudio config AppArmor rules

### DIFF
--- a/bluetooth_audio_manager/apparmor.txt
+++ b/bluetooth_audio_manager/apparmor.txt
@@ -37,8 +37,8 @@ profile bluetooth_audio_manager flags=(attach_disconnected,mediate_deleted) {
   /run/pulse/** rw,
   /etc/pulse/** r,
   /tmp/pulse-*/** rw,
-  /root/.config/pulse/ rw,
-  /root/.config/pulse/** rw,
+  /root/.config/pulse/ rwk,
+  /root/.config/pulse/** rwk,
 
   # Persistent data storage (k = flock, needed by MPD state/database)
   /data/** rwk,

--- a/bluetooth_audio_manager_dev/apparmor.txt
+++ b/bluetooth_audio_manager_dev/apparmor.txt
@@ -37,8 +37,8 @@ profile bluetooth_audio_manager flags=(attach_disconnected,mediate_deleted) {
   /run/pulse/** rw,
   /etc/pulse/** r,
   /tmp/pulse-*/** rw,
-  /root/.config/pulse/ rw,
-  /root/.config/pulse/** rw,
+  /root/.config/pulse/ rwk,
+  /root/.config/pulse/** rwk,
 
   # Persistent data storage (k = flock, needed by MPD state/database)
   /data/** rwk,


### PR DESCRIPTION
## Summary
- Adds `k` (flock) permission to `/root/.config/pulse/` AppArmor rules to fix the one-time `lock: Permission denied` on first playback

## Root cause
MPD lazy-initializes the PulseAudio output on first play. libpulse tries to `flock()` the cookie file in `/root/.config/pulse/`. This path had `rw` but not `k`, and isn't covered by any broader `rwk` rule (unlike `/run/pulse/**` which is covered by `/run/** rwk`).

## Note
This also needs to land on main (Supervisor reads AppArmor from main). Will create a separate PR for that after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)