### PR TITLE
Auto-import paired BlueZ devices after data wipe

### DIFF
--- a/src/bt_audio_manager/persistence/store.py
+++ b/src/bt_audio_manager/persistence/store.py
@@ -50,6 +50,14 @@ class PersistenceStore:
             data = json.loads(self._path.read_text())
             self._devices = data.get("devices", [])
             logger.info("Loaded %d paired device(s) from store", len(self._devices))
+            for d in self._devices:
+                non_defaults = {
+                    k: d[k]
+                    for k in DEFAULT_DEVICE_SETTINGS
+                    if k in d and d[k] != DEFAULT_DEVICE_SETTINGS[k]
+                }
+                if non_defaults:
+                    logger.info("  %s: custom settings: %s", d.get("address", "?"), non_defaults)
         except (json.JSONDecodeError, KeyError) as e:
             logger.error("Failed to parse paired devices store: %s", e)
             self._devices = []


### PR DESCRIPTION
## Summary
- After reinstall with data wipe, BlueZ still knows paired devices but the add-on store is empty — saving settings failed with "Device not found"
- Phase 6b now auto-imports all paired audio devices from BlueZ into the persistence store at startup, with a warning toast so users know settings were reset to defaults
- Settings endpoint fallback improved to create BlueZ wrappers on-the-fly for edge cases
- Diagnostic logging added to `store.load()` to help debug a separate "no-data-wipe but settings lost" issue

## Test plan
- [ ] Pair a device, enable MPD + customize settings, confirm save works
- [ ] Uninstall add-on **with** "delete data", reinstall → device appears in UI, warning toast fires, settings save succeeds
- [ ] Uninstall add-on **without** "delete data", reinstall → no toast, existing settings preserved (check logs for "custom settings" line)
- [ ] Normal restart (no reinstall) → no toast, all settings intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)