### PR TITLE
Move persistent storage to addon_config for reinstall survival

### DIFF
--- a/bluetooth_audio_manager/apparmor.txt
+++ b/bluetooth_audio_manager/apparmor.txt
@@ -44,6 +44,10 @@ profile bluetooth_audio_manager flags=(attach_disconnected,mediate_deleted) {
   /data/** rwk,
   /data/ r,
 
+  # Persistent config storage (survives reinstall via addon_config)
+  /config/** rwk,
+  /config/ r,
+
   # Temporary files (k = flock, needed by MPD state/database)
   /tmp/** rwk,
 

--- a/bluetooth_audio_manager/config.yaml
+++ b/bluetooth_audio_manager/config.yaml
@@ -33,6 +33,8 @@ panel_title: "BT Audio"
 map:
   - type: data
     read_only: false
+  - type: addon_config
+    read_only: false
 
 # User options (runtime settings are managed in the app UI)
 options:

--- a/bluetooth_audio_manager_dev/apparmor.txt
+++ b/bluetooth_audio_manager_dev/apparmor.txt
@@ -44,6 +44,10 @@ profile bluetooth_audio_manager flags=(attach_disconnected,mediate_deleted) {
   /data/** rwk,
   /data/ r,
 
+  # Persistent config storage (survives reinstall via addon_config)
+  /config/** rwk,
+  /config/ r,
+
   # Temporary files (k = flock, needed by MPD state/database)
   /tmp/** rwk,
 

--- a/bluetooth_audio_manager_dev/config.yaml
+++ b/bluetooth_audio_manager_dev/config.yaml
@@ -33,6 +33,8 @@ panel_title: "BT Audio Dev"
 map:
   - type: data
     read_only: false
+  - type: addon_config
+    read_only: false
 
 # User options (runtime settings are managed in the app UI)
 options:

--- a/src/bt_audio_manager/manager.py
+++ b/src/bt_audio_manager/manager.py
@@ -2593,8 +2593,8 @@ class BluetoothAudioManager:
         enable keep-alive on all stored devices."""
         from pathlib import Path
 
-        marker = Path("/data/.keepalive_migrated")
-        if marker.exists():
+        marker = Path("/config/.keepalive_migrated")
+        if marker.exists() or Path("/data/.keepalive_migrated").exists():
             return
         try:
             opts_path = Path("/data/options.json")
@@ -2611,6 +2611,7 @@ class BluetoothAudioManager:
                             device_info["address"],
                             {"idle_mode": "keep_alive", "keep_alive_method": method},
                         )
+            marker.parent.mkdir(parents=True, exist_ok=True)
             marker.write_text("migrated")
         except Exception as e:
             logger.warning("Keep-alive migration failed (non-fatal): %s", e)

--- a/src/bt_audio_manager/persistence/store.py
+++ b/src/bt_audio_manager/persistence/store.py
@@ -1,7 +1,8 @@
 """JSON-backed persistent store for paired device information.
 
-Data is stored in /data/paired_devices.json which persists across
-container restarts, app updates, and is included in HA backups.
+Data is stored in /config/paired_devices.json (addon_config) which
+persists across container restarts, app updates, reinstalls, and is
+included in HA backups.  Legacy /data/ location is auto-migrated.
 """
 
 import json
@@ -12,7 +13,8 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_STORE_PATH = "/data/paired_devices.json"
+DEFAULT_STORE_PATH = "/config/paired_devices.json"
+LEGACY_STORE_PATH = "/data/paired_devices.json"
 
 # Per-device settings with their default values.
 # Existing device records without these keys get defaults automatically.
@@ -41,6 +43,13 @@ class PersistenceStore:
 
     async def load(self) -> None:
         """Load paired devices from disk."""
+        # Migrate from /data/ to /config/ (one-time, for users upgrading)
+        legacy = Path(LEGACY_STORE_PATH)
+        if not self._path.exists() and legacy.exists():
+            logger.info("Migrating paired devices from %s to %s", legacy, self._path)
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            self._path.write_text(legacy.read_text())
+
         if not self._path.exists():
             self._devices = []
             logger.info("No existing paired devices store found")


### PR DESCRIPTION
## Summary
- The HA Supervisor **unconditionally deletes** `/data/` on uninstall — the "Also remove app data" checkbox only controls the `addon_config` folder, not `/data/`. This was confirmed by reading the Supervisor source code ([`addon.py` `unload()` method](https://github.com/home-assistant/supervisor/blob/main/supervisor/addons/addon.py)).
- Migrate `paired_devices.json` and `settings.json` from `/data/` to `/config/` (`addon_config` mapping) so they survive reinstall
- Auto-migration from `/data/` → `/config/` on first startup after upgrade (transparent to users)
- AppArmor updated with `/config/** rwk,` rules (flock permission needed by MPD and atomic saves)
- `options.json` stays in `/data/` (Supervisor-managed, cannot move)

## Test plan
- [ ] Fresh install: files created in `/config/`, works normally
- [ ] Upgrade from existing install: migration logs show, files copied from `/data/` to `/config/`, settings preserved
- [ ] Uninstall WITHOUT "delete data" → reinstall: `/config/` files survive, no toast, settings intact
- [ ] Uninstall WITH "delete data" → reinstall: BlueZ auto-import fires, toast warns about defaults
- [ ] Verify from Terminal: `ls /addon_configs/` shows the bluetooth audio manager directory
- [ ] Verify AppArmor: no permission denied errors in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)