### PR TITLE
Add /config/ AppArmor rules and sync apparmor.txt in dev workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -323,16 +323,17 @@ jobs:
           ref: main
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Sync dev config.yaml from dev branch and set version
+      - name: Sync dev metadata from dev branch and set version
         run: |
           SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
-          # Fetch the full dev config.yaml from the dev branch so options/schema
-          # changes propagate to main (HAOS reads config.yaml from main)
+          # Fetch dev metadata from the dev branch so config, apparmor, etc.
+          # propagate to main (HAOS Supervisor reads these from main)
           git fetch origin dev --depth=1
           git show origin/dev:bluetooth_audio_manager_dev/config.yaml > bluetooth_audio_manager_dev/config.yaml
+          git show origin/dev:bluetooth_audio_manager_dev/apparmor.txt > bluetooth_audio_manager_dev/apparmor.txt
           # Override version with the build SHA
           sed -i "s/^version: .*/version: \"sha-${SHORT_SHA}\"/" bluetooth_audio_manager_dev/config.yaml
-          echo "Synced bluetooth_audio_manager_dev/config.yaml from dev:"
+          echo "Synced bluetooth_audio_manager_dev/ metadata from dev:"
           cat bluetooth_audio_manager_dev/config.yaml
 
       - name: Create PR for version update
@@ -344,7 +345,7 @@ jobs:
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add bluetooth_audio_manager_dev/config.yaml
+          git add bluetooth_audio_manager_dev/config.yaml bluetooth_audio_manager_dev/apparmor.txt
           if git diff --staged --quiet; then
             echo "No version change needed"
             exit 0

--- a/bluetooth_audio_manager/apparmor.txt
+++ b/bluetooth_audio_manager/apparmor.txt
@@ -44,6 +44,10 @@ profile bluetooth_audio_manager flags=(attach_disconnected,mediate_deleted) {
   /data/** rwk,
   /data/ r,
 
+  # Persistent config storage (survives reinstall via addon_config)
+  /config/** rwk,
+  /config/ r,
+
   # Temporary files (k = flock, needed by MPD state/database)
   /tmp/** rwk,
 

--- a/bluetooth_audio_manager_dev/apparmor.txt
+++ b/bluetooth_audio_manager_dev/apparmor.txt
@@ -44,6 +44,10 @@ profile bluetooth_audio_manager flags=(attach_disconnected,mediate_deleted) {
   /data/** rwk,
   /data/ r,
 
+  # Persistent config storage (survives reinstall via addon_config)
+  /config/** rwk,
+  /config/ r,
+
   # Temporary files (k = flock, needed by MPD state/database)
   /tmp/** rwk,
 


### PR DESCRIPTION
## Summary
- The HAOS Supervisor reads add-on metadata (`config.yaml`, `apparmor.txt`) from `main`. The dev build workflow was only syncing `config.yaml` from dev → main, so the new `addon_config` `/config/` AppArmor rules never reached main — causing `PermissionError` on writes to `/config/` in the dev add-on.
- Adds `/config/** rwk,` rules to both stable and dev AppArmor profiles
- Updates the build workflow to sync `apparmor.txt` alongside `config.yaml` on dev builds

## Test plan
- [ ] Merge to main, then `ha store reload` + restart dev add-on
- [ ] Verify add-on starts without `PermissionError` on `/config/settings.json`
- [ ] Verify settings and paired devices persist in `/config/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)