### PR TITLE
Fix auto-import missing devices on multi-adapter systems

### DIFF
--- a/src/bt_audio_manager/web/static/app.js
+++ b/src/bt_audio_manager/web/static/app.js
@@ -144,6 +144,27 @@ function hideBanner() {
   if (existing) existing.remove();
 }
 
+function showWarningBanner(text) {
+  hideWarningBanner();
+  const container = $("#alert-container");
+  if (!container) return;
+  const el = document.createElement("div");
+  el.id = "warning-banner";
+  el.className = "alert alert-warning alert-dismissible d-flex align-items-center gap-2 mb-3";
+  el.setAttribute("role", "alert");
+  el.innerHTML = `
+    <i class="fas fa-exclamation-triangle"></i>
+    <span>${escapeHtml(text)}</span>
+    <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+  `;
+  container.prepend(el);
+}
+
+function hideWarningBanner() {
+  const existing = $("#warning-banner");
+  if (existing) existing.remove();
+}
+
 // ============================================
 // Section 5a: Scanning State
 // ============================================
@@ -1216,6 +1237,9 @@ function connectWebSocket() {
         break;
       case "toast":
         showToast(msg.message, msg.level || "info");
+        break;
+      case "warning_banner":
+        showWarningBanner(msg.message);
         break;
       default:
         console.log("[WS] Unknown message type:", msg.type);


### PR DESCRIPTION
## Summary
- **Bug**: After uninstall+wipe+reinstall with two adapters, Phase 6b only scanned the auto-selected adapter (hci0). Devices paired on hci1 were invisible — no reimport toast, no settings saved.
- **Fix**: Phase 6b now scans ALL adapters for paired audio devices to import into the store. Managed device wrappers are still only created for the selected adapter.
- **Smart auto-select**: When multiple powered adapters exist, `_pick_best_adapter()` chooses the one with the most paired audio devices (tie-break: lowest hci index).
- **Warning banner**: If reimported devices span multiple adapters, a persistent dismissible warning banner tells the user to consolidate devices onto one adapter.
- **Cleanup**: Added `_dbus_val()` helper to replace repetitive D-Bus Variant unwrapping boilerplate in Phase 6b.

## Test plan
- [ ] Two adapters, device on hci1 only: auto-selects hci1, imports device, shows reimport toast, no multi-adapter warning
- [ ] Two adapters, devices on both: auto-selects adapter with more devices, imports all, shows reimport toast + warning banner
- [ ] One adapter: no change in behavior, imports device normally
- [ ] No devices paired: no import, no toast (existing behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)