### PR TITLE
Show Supervisor hostname and password in MPD info

### DIFF
--- a/src/bt_audio_manager/web/api.py
+++ b/src/bt_audio_manager/web/api.py
@@ -93,6 +93,7 @@ def create_api_routes(
     async def info(request: web.Request) -> web.Response:
         """Return app version and adapter info for the UI."""
         import os
+        import socket
         from ..bluez.constants import HFP_SWITCHING_ENABLED
         path = manager._adapter_path or "/org/bluez/hci0"
         adapter_name = path.rsplit("/", 1)[-1]
@@ -103,6 +104,8 @@ def create_api_routes(
             "adapter_mac": manager.config.bt_adapter
             if manager.config.bt_adapter_is_mac else None,
             "hfp_switching_enabled": HFP_SWITCHING_ENABLED,
+            "hostname": socket.gethostname(),
+            "mpd_password_set": manager._get_mpd_password() is not None,
         })
 
     @routes.get("/api/adapters")

--- a/src/bt_audio_manager/web/static/app.js
+++ b/src/bt_audio_manager/web/static/app.js
@@ -1045,7 +1045,8 @@ function openDeviceSettings(address, name, audioProfile, idleMode, kaMethod, pow
   // Show connection info if port is assigned
   if (mpdPort) {
     $("#mpd-port-display").textContent = mpdPort;
-    $("#mpd-hostname").textContent = location.hostname;
+    $("#mpd-hostname").textContent = window._mpdHostname || location.hostname;
+    $("#mpd-password-display").textContent = window._mpdPasswordSet ? "**********" : "None";
     $("#mpd-connection-info").style.display = "";
   } else {
     $("#mpd-connection-info").style.display = "none";
@@ -1096,7 +1097,8 @@ function toggleMpdConfigVisibility() {
       if (!usedPorts.has(p)) {
         $("#setting-mpd-port").value = p;
         $("#mpd-port-display").textContent = p;
-        $("#mpd-hostname").textContent = location.hostname;
+        $("#mpd-hostname").textContent = window._mpdHostname || location.hostname;
+        $("#mpd-password-display").textContent = window._mpdPasswordSet ? "**********" : "None";
         $("#mpd-connection-info").style.display = "";
         break;
       }
@@ -1324,6 +1326,8 @@ document.addEventListener("DOMContentLoaded", () => {
       $("#build-version").textContent = ver;
       $("#version-label").textContent = `${ver} (${data.adapter})`;
       window._hfpSwitchingEnabled = !!data.hfp_switching_enabled;
+      window._mpdHostname = data.hostname || location.hostname;
+      window._mpdPasswordSet = !!data.mpd_password_set;
     })
     .catch(() => {
       $("#build-version").textContent = "unknown";

--- a/src/bt_audio_manager/web/static/index.html
+++ b/src/bt_audio_manager/web/static/index.html
@@ -409,7 +409,8 @@
             <div class="alert alert-info py-2 mb-0" id="mpd-connection-info">
               <i class="fas fa-info-circle me-1"></i>
               Use port <strong id="mpd-port-display"></strong> when adding the HA MPD integration.<br>
-              <span class="form-text">Host: <code id="mpd-hostname"></code></span>
+              <span class="form-text">Host: <code id="mpd-hostname"></code></span><br>
+              <span class="form-text">Password: <code id="mpd-password-display"></code></span>
             </div>
           </div>
 


### PR DESCRIPTION
## Summary
- Replace browser IP (`location.hostname`) with the container's Supervisor DNS hostname in the MPD connection info banner
- Show password status: `**********` if an MPD password is configured in add-on options, `None` otherwise
- Both values served from `/api/info` endpoint so the UI displays accurate server-side info

## Test plan
- [ ] Open device settings for a device with MPD enabled — verify Host shows the Supervisor DNS name (not the browser IP)
- [ ] With no MPD password configured in add-on options — verify Password shows `None`
- [ ] Set an MPD password in add-on options and restart — verify Password shows `**********`

🤖 Generated with [Claude Code](https://claude.com/claude-code)