### PR TITLE
feat: add RSSI signal strength indicator

### DIFF
--- a/src/bt_audio_manager/bluez/adapter.py
+++ b/src/bt_audio_manager/bluez/adapter.py
@@ -3,6 +3,7 @@
 import asyncio
 import logging
 import os
+import re
 
 from dbus_next import Variant
 from dbus_next.aio import MessageBus
@@ -295,6 +296,31 @@ class BluezAdapter:
                 parts.append(f"{cod_accepted} matched by CoD fallback")
             logger.info("get_audio_devices: %s", ", ".join(parts))
         return devices
+
+    @staticmethod
+    async def get_connected_rssi(address: str) -> int | None:
+        """Get RSSI for a connected BR/EDR device via hcitool.
+
+        Returns the RSSI value in dBm, or None if the device is not
+        connected or hcitool is unavailable.
+        """
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                "hcitool", "rssi", address,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=5)
+            # Output format: "RSSI return value: -52"
+            match = re.search(r"(-?\d+)", stdout.decode())
+            return int(match.group(1)) if match else None
+        except FileNotFoundError:
+            logger.debug("hcitool not found — RSSI polling unavailable")
+            return None
+        except asyncio.TimeoutError:
+            return None
+        except Exception:
+            return None
 
     async def remove_device(self, device_path: str) -> None:
         """Remove a device from the adapter (unpair)."""

--- a/src/bt_audio_manager/manager.py
+++ b/src/bt_audio_manager/manager.py
@@ -38,6 +38,21 @@ def _dbus_val(variant, default=None):
     return variant.value if hasattr(variant, "value") else variant
 
 
+def classify_signal(rssi: int | None) -> str | None:
+    """Classify RSSI (dBm) into a signal quality label."""
+    if rssi is None:
+        return None
+    if rssi > -50:
+        return "excellent"
+    if rssi > -65:
+        return "good"
+    if rssi > -75:
+        return "fair"
+    if rssi > -85:
+        return "weak"
+    return "very_weak"
+
+
 # Common Bluetooth USB vendor IDs → friendly vendor names.
 # Used as a last-resort fallback when both sysfs and the Supervisor's
 # udev database lack a human-readable product name.
@@ -82,6 +97,8 @@ class BluetoothAudioManager:
         self._web_server = None
         self.event_bus = EventBus()
         self._sink_poll_task: asyncio.Task | None = None
+        self._rssi_poll_task: asyncio.Task | None = None
+        self._connected_rssi: dict[str, int | None] = {}  # addr → last RSSI
         self._last_sink_snapshot: str = ""
         self._last_signaled_volume: dict[str, int] = {}  # addr → raw 0-127
         self._last_pa_volume: dict[str, int] = {}  # addr → last PA vol% synced to MPD
@@ -614,6 +631,7 @@ class BluetoothAudioManager:
 
         # 10. Start periodic sink state polling
         self._sink_poll_task = asyncio.create_task(self._sink_poll_loop())
+        self._rssi_poll_task = asyncio.create_task(self._rssi_poll_loop())
 
         logger.info("Bluetooth Audio Manager started successfully")
 
@@ -621,13 +639,14 @@ class BluetoothAudioManager:
         """Graceful teardown in reverse order."""
         logger.info("Shutting down Bluetooth Audio Manager...")
 
-        # Stop sink polling
-        if self._sink_poll_task and not self._sink_poll_task.done():
-            self._sink_poll_task.cancel()
-            try:
-                await self._sink_poll_task
-            except asyncio.CancelledError:
-                pass
+        # Stop sink and RSSI polling
+        for task in (self._sink_poll_task, self._rssi_poll_task):
+            if task and not task.done():
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
 
         # Cancel any running scan
         if self._scan_task and not self._scan_task.done():
@@ -1281,6 +1300,20 @@ class BluetoothAudioManager:
                     }
                 )
 
+        # Enrich with polled RSSI for connected devices + signal quality
+        for device in discovered:
+            addr = device["address"]
+            # Use polled RSSI for connected devices (more current than D-Bus)
+            if device["connected"] and addr in self._connected_rssi:
+                device["rssi"] = self._connected_rssi[addr]
+            rssi = device.get("rssi")
+            quality = classify_signal(rssi)
+            device["signal_quality"] = quality
+            device["signal_warning"] = (
+                "Weak signal \u2014 audio may stutter or drop"
+                if quality in ("weak", "very_weak") else None
+            )
+
         return discovered
 
     async def get_audio_sinks(self) -> list[dict]:
@@ -1562,6 +1595,46 @@ class BluetoothAudioManager:
             except Exception as e:
                 logger.debug("Sink poll error: %s", e)
 
+    # -- RSSI polling --
+
+    RSSI_POLL_INTERVAL = 30  # seconds
+
+    async def _rssi_poll_loop(self) -> None:
+        """Periodically poll RSSI for connected devices via hcitool."""
+        while True:
+            try:
+                await asyncio.sleep(self.RSSI_POLL_INTERVAL)
+                connected_addrs = [
+                    addr for addr, dev in self.managed_devices.items()
+                    if dev.connected
+                ]
+                if not connected_addrs:
+                    continue
+
+                changed = False
+                for addr in connected_addrs:
+                    rssi = await BluezAdapter.get_connected_rssi(addr)
+                    prev = self._connected_rssi.get(addr)
+                    self._connected_rssi[addr] = rssi
+                    # Broadcast only on significant change (>=3 dBm) or None transition
+                    if prev is None and rssi is None:
+                        continue
+                    if prev is None or rssi is None or abs(rssi - prev) >= 3:
+                        changed = True
+
+                # Clean up disconnected devices
+                for addr in list(self._connected_rssi):
+                    if addr not in self.managed_devices or not self.managed_devices[addr].connected:
+                        del self._connected_rssi[addr]
+                        changed = True
+
+                if changed:
+                    await self._broadcast_devices()
+            except asyncio.CancelledError:
+                return
+            except Exception as e:
+                logger.debug("RSSI poll error: %s", e)
+
     # -- SSE broadcast helpers --
 
     async def _broadcast_devices(self, *, cod_fallback: bool = False) -> None:
@@ -1595,6 +1668,7 @@ class BluetoothAudioManager:
         self._device_connect_time.pop(address, None)
         self._last_signaled_volume.pop(address, None)
         self._last_pa_volume.pop(address, None)
+        self._connected_rssi.pop(address, None)
         # Clean up running sink tracking for this device
         addr_underscored = address.replace(":", "_")
         self._running_sinks = {s for s in self._running_sinks if addr_underscored not in s}

--- a/src/bt_audio_manager/web/static/app.js
+++ b/src/bt_audio_manager/web/static/app.js
@@ -455,7 +455,14 @@ function renderDevices(devices) {
         `;
       }
 
-      const rssiDisplay = d.rssi ? ` (${d.rssi} dBm)` : "";
+      let rssiDisplay = "";
+      if (d.rssi != null) {
+        const colorClass =
+          d.signal_quality === "excellent" || d.signal_quality === "good" ? "text-success"
+          : d.signal_quality === "fair" ? "text-warning"
+          : "text-danger";
+        rssiDisplay = ` <i class="fas fa-signal ${colorClass}" title="${d.rssi} dBm (${d.signal_quality || "unknown"})"></i>`;
+      }
       const profiles = profileLabels(d.uuids);
 
       // Merge sink info for connected devices
@@ -497,6 +504,7 @@ function renderDevices(devices) {
               ${buildCapBadges(d)}
               <div class="device-meta-text font-monospace text-muted">${escapeHtml(d.address)}${rssiDisplay}${d.adapter ? ` on ${escapeHtml(d.adapter)}` : ""}</div>
               ${d.cod_matched && !d.paired ? '<div class="device-meta-text mt-1 text-warning-emphasis"><i class="fas fa-info-circle me-1"></i>Detected by device class \u2014 pair to confirm audio support</div>' : d.paired && !profiles ? '<div class="device-meta-text mt-1 text-warning-emphasis"><i class="fas fa-exclamation-triangle me-1"></i>Paired but no audio profiles found</div>' : profiles ? `<div class="device-meta-text device-profiles-text mt-1 text-muted">${escapeHtml(profiles)}</div>` : ""}
+              ${d.signal_warning ? `<div class="device-meta-text mt-1 text-warning-emphasis"><i class="fas fa-exclamation-triangle me-1"></i>${escapeHtml(d.signal_warning)}</div>` : ""}
               ${sinkInfo}
               ${(() => { const fb = buildFeatureBadges(d); return fb ? `<div class="device-feature-badges d-flex gap-2 flex-wrap">${fb}</div>` : ""; })()}
               <div class="device-actions">


### PR DESCRIPTION
## Summary
- Poll RSSI for connected BT devices via `hcitool rssi` every 30s
- Classify signal quality (excellent/good/fair/weak/very_weak) with color-coded `fa-signal` icon (green/amber/red)
- Show warning text when signal is too weak for reliable A2DP streaming (<= -75 dBm)
- Tooltip on icon shows exact dBm value and quality label

## Test plan
- [ ] Connect a BT device, confirm RSSI icon appears with color after ~30s
- [ ] Hover icon to verify tooltip shows dBm and quality
- [ ] Verify offline/unpaired devices show no signal indicator
- [ ] Verify warning text appears when RSSI is weak
- [ ] Verify `hcitool` unavailability is handled gracefully (no crash, no indicator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)