### PR TITLE
Update AppArmor comment for hcitool socket access

### DIFF
--- a/bluetooth_audio_manager/apparmor.txt
+++ b/bluetooth_audio_manager/apparmor.txt
@@ -97,9 +97,11 @@ profile bluetooth_audio_manager flags=(attach_disconnected,mediate_deleted) {
   network unix dgram,
   network bluetooth,
 
-  # CRITICAL: block raw HCI device access
-  # All Bluetooth operations MUST go through BlueZ D-Bus to avoid
-  # interfering with HA's passive BLE scanning and other integrations.
+  # Block raw HCI character-device access — all Bluetooth configuration
+  # MUST go through BlueZ D-Bus to avoid interfering with HA's passive
+  # BLE scanning and other integrations.  Note: hcitool rssi uses
+  # AF_BLUETOOTH sockets (permitted by "network bluetooth" above),
+  # NOT /dev/hci* character devices, so this deny does not block it.
   deny /dev/hci* rw,
   deny /sys/kernel/** rw,
   deny /proc/sys/** w,

--- a/bluetooth_audio_manager_dev/apparmor.txt
+++ b/bluetooth_audio_manager_dev/apparmor.txt
@@ -97,9 +97,11 @@ profile bluetooth_audio_manager flags=(attach_disconnected,mediate_deleted) {
   network unix dgram,
   network bluetooth,
 
-  # CRITICAL: block raw HCI device access
-  # All Bluetooth operations MUST go through BlueZ D-Bus to avoid
-  # interfering with HA's passive BLE scanning and other integrations.
+  # Block raw HCI character-device access — all Bluetooth configuration
+  # MUST go through BlueZ D-Bus to avoid interfering with HA's passive
+  # BLE scanning and other integrations.  Note: hcitool rssi uses
+  # AF_BLUETOOTH sockets (permitted by "network bluetooth" above),
+  # NOT /dev/hci* character devices, so this deny does not block it.
   deny /dev/hci* rw,
   deny /sys/kernel/** rw,
   deny /proc/sys/** w,


### PR DESCRIPTION
## Summary
- Updates the AppArmor comment on the `/dev/hci*` deny rule to clarify that `hcitool rssi` uses AF_BLUETOOTH sockets (not character devices), so the deny rule doesn't block it

This syncs the main branch's `apparmor.txt` with the comment update from PR #232 (on dev), so the Supervisor picks up the accurate comment.

## Test plan
- [ ] Comment-only change — no functional impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)