### PR TITLE
Replace hcitool RSSI with silent discovery bursts

### DIFF
--- a/bluetooth_audio_manager/apparmor.txt
+++ b/bluetooth_audio_manager/apparmor.txt
@@ -99,9 +99,7 @@ profile bluetooth_audio_manager flags=(attach_disconnected,mediate_deleted) {
 
   # Block raw HCI character-device access — all Bluetooth configuration
   # MUST go through BlueZ D-Bus to avoid interfering with HA's passive
-  # BLE scanning and other integrations.  Note: hcitool rssi uses
-  # AF_BLUETOOTH sockets (permitted by "network bluetooth" above),
-  # NOT /dev/hci* character devices, so this deny does not block it.
+  # BLE scanning and other integrations.
   deny /dev/hci* rw,
   deny /sys/kernel/** rw,
   deny /proc/sys/** w,

--- a/bluetooth_audio_manager_dev/apparmor.txt
+++ b/bluetooth_audio_manager_dev/apparmor.txt
@@ -99,9 +99,7 @@ profile bluetooth_audio_manager flags=(attach_disconnected,mediate_deleted) {
 
   # Block raw HCI character-device access — all Bluetooth configuration
   # MUST go through BlueZ D-Bus to avoid interfering with HA's passive
-  # BLE scanning and other integrations.  Note: hcitool rssi uses
-  # AF_BLUETOOTH sockets (permitted by "network bluetooth" above),
-  # NOT /dev/hci* character devices, so this deny does not block it.
+  # BLE scanning and other integrations.
   deny /dev/hci* rw,
   deny /sys/kernel/** rw,
   deny /proc/sys/** w,

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,6 @@ RUN apk add --no-cache \
     --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community \
     bluez \
     bluez-btmon \
-    bluez-deprecated \
     bluez-libs \
     mpd \
     && rm -f /etc/mpd.conf \

--- a/src/bt_audio_manager/bluez/adapter.py
+++ b/src/bt_audio_manager/bluez/adapter.py
@@ -162,6 +162,10 @@ class BluezAdapter:
         finally:
             self._rssi_refreshing = False
 
+    def clear_logged_cache(self) -> None:
+        """Clear the per-scan device log cache to prevent unbounded growth."""
+        self._logged_cache.clear()
+
     async def get_audio_devices(self, *, cod_fallback: bool = False) -> list[dict]:
         """Enumerate discovered devices that can receive/play audio.
 

--- a/src/bt_audio_manager/bluez/adapter.py
+++ b/src/bt_audio_manager/bluez/adapter.py
@@ -63,6 +63,7 @@ class BluezAdapter:
         self._adapter_iface = None
         self._properties_iface = None
         self._discovering = False
+        self._rssi_refreshing = False
         # Tracks addresses already logged during this scan session,
         # so each device is logged at INFO only once per scan.
         self._logged_cache: set[str] = set()
@@ -128,6 +129,38 @@ class BluezAdapter:
         finally:
             self._discovering = False
         logger.info("Device discovery stopped")
+
+    async def start_rssi_refresh(self) -> None:
+        """Start a silent discovery burst to refresh RSSI values.
+
+        Unlike start_discovery(), this does NOT clear the logged-device
+        cache (avoiding INFO-level "Skipping device" spam) and does not
+        set _discovering (so stop_discovery() won't interfere).  The
+        manager calls this without setting _scanning=True, so no UI
+        scan events are triggered.
+        """
+        if self._discovering or self._rssi_refreshing:
+            return
+        try:
+            await self._adapter_iface.call_set_discovery_filter(
+                {"Transport": Variant("s", "auto")}
+            )
+            await self._adapter_iface.call_start_discovery()
+            self._rssi_refreshing = True
+        except DBusError as e:
+            logger.debug("RSSI refresh start failed: %s", e)
+
+    async def stop_rssi_refresh(self) -> None:
+        """Stop the silent RSSI discovery burst."""
+        if not self._rssi_refreshing:
+            return
+        try:
+            await self._adapter_iface.call_stop_discovery()
+        except DBusError as e:
+            if "No discovery started" not in str(e):
+                logger.debug("RSSI refresh stop failed: %s", e)
+        finally:
+            self._rssi_refreshing = False
 
     async def get_audio_devices(self, *, cod_fallback: bool = False) -> list[dict]:
         """Enumerate discovered devices that can receive/play audio.

--- a/src/bt_audio_manager/manager.py
+++ b/src/bt_audio_manager/manager.py
@@ -9,7 +9,6 @@ import collections
 import json
 import logging
 import os
-import re
 import time
 
 from dbus_next.aio import MessageBus
@@ -76,7 +75,8 @@ class BluetoothAudioManager:
     """Central orchestrator for the Bluetooth Audio Manager app."""
 
     SINK_POLL_INTERVAL = 5  # seconds between sink state polls
-    RSSI_POLL_INTERVAL = 30  # seconds between hcitool RSSI polls
+    RSSI_REFRESH_INTERVAL = 60  # seconds between silent discovery bursts
+    RSSI_REFRESH_DURATION = 5   # seconds per silent discovery burst
     MAX_RECENT_EVENTS = 50  # ring buffer size for MPRIS/AVRCP events
 
     def __init__(self, config: AppConfig):
@@ -637,7 +637,7 @@ class BluetoothAudioManager:
 
         # 10. Start periodic sink state polling
         self._sink_poll_task = asyncio.create_task(self._sink_poll_loop())
-        self._rssi_poll_task = asyncio.create_task(self._rssi_poll_loop())
+        self._rssi_poll_task = asyncio.create_task(self._rssi_refresh_loop())
 
         logger.info("Bluetooth Audio Manager started successfully")
 
@@ -1306,7 +1306,7 @@ class BluetoothAudioManager:
                     }
                 )
 
-        # Enrich with cached RSSI (D-Bus discovery + hcitool polling) + signal quality
+        # Enrich with cached RSSI (D-Bus discovery + silent refresh bursts) + signal quality
         for device in discovered:
             addr = device["address"]
             # Use cached RSSI for devices currently visible to BlueZ
@@ -1602,7 +1602,7 @@ class BluetoothAudioManager:
             except Exception as e:
                 logger.debug("Sink poll error: %s", e)
 
-    # -- RSSI tracking (D-Bus events + hcitool polling) --
+    # -- RSSI tracking (D-Bus discovery events + silent refresh bursts) --
 
     def _handle_rssi_update(self, dbus_path: str, rssi_variant) -> None:
         """Extract RSSI from a D-Bus PropertiesChanged signal and cache it.
@@ -1626,69 +1626,57 @@ class BluetoothAudioManager:
         if prev is None or abs(rssi - prev) >= 3:
             asyncio.ensure_future(self._broadcast_devices())
 
-    @staticmethod
-    async def _hcitool_rssi(address: str, hci_dev: str = "hci0") -> int | None:
-        """Query live RSSI for a connected BR/EDR device via hcitool.
+    async def _rssi_refresh_loop(self) -> None:
+        """Periodically run silent discovery bursts to refresh RSSI.
 
-        Uses AF_BLUETOOTH sockets (not /dev/hci*), so AppArmor's deny on
-        HCI character devices does not block this.  Returns RSSI in dBm,
-        or None on any failure.
+        BlueZ only emits RSSI via PropertiesChanged during active
+        discovery.  This loop runs short discovery bursts without
+        setting _scanning=True, so RSSI signals are captured and
+        cached by _handle_rssi_update() but no UI scan activity is
+        triggered (no "device discovered" logs, no scan_started events).
+
+        Skips the burst if a user-initiated scan is already running.
         """
-        try:
-            proc = await asyncio.create_subprocess_exec(
-                "hcitool", "-i", hci_dev, "rssi", address,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-            )
-            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=5)
-            # Output format: "RSSI return value: -52"
-            match = re.search(r"(-?\d+)", stdout.decode())
-            return int(match.group(1)) if match else None
-        except FileNotFoundError:
-            logger.debug("hcitool not found — RSSI polling unavailable")
-            return None
-        except asyncio.TimeoutError:
-            proc.kill()
-            return None
-        except Exception:
-            return None
-
-    async def _rssi_poll_loop(self) -> None:
-        """Poll RSSI for connected devices via hcitool and clean stale entries."""
         while True:
             try:
-                await asyncio.sleep(self.RSSI_POLL_INTERVAL)
+                await asyncio.sleep(self.RSSI_REFRESH_INTERVAL)
 
-                # Poll connected devices via hcitool
-                connected_addrs = list(self._device_connect_time.keys())
-                changed = False
-                # Extract HCI device name (e.g. "hci0") from adapter path
-                hci_dev = self._adapter_path.rsplit("/", 1)[-1] if self._adapter_path else "hci0"
+                # Skip if user scan is active — discovery is already running
+                if self._scanning:
+                    continue
 
-                for addr in connected_addrs:
-                    rssi = await self._hcitool_rssi(addr, hci_dev)
-                    if rssi is None:
-                        continue  # keep existing cached value on failure
-                    prev = self._connected_rssi.get(addr)
-                    self._connected_rssi[addr] = rssi
-                    if prev is None or abs(rssi - prev) >= 3:
-                        changed = True
+                # Skip if no connected devices need RSSI
+                if not self._device_connect_time:
+                    # Cleanup stale entries while we're here
+                    self._rssi_cleanup()
+                    continue
 
-                # Cleanup: remove entries for devices no longer known
-                for addr in list(self._connected_rssi):
-                    if addr in self.managed_devices:
-                        continue
-                    if addr in self._device_connect_time:
-                        continue
-                    del self._connected_rssi[addr]
-                    changed = True
+                try:
+                    await self.adapter.start_rssi_refresh()
+                    await asyncio.sleep(self.RSSI_REFRESH_DURATION)
+                finally:
+                    await self.adapter.stop_rssi_refresh()
 
-                if changed:
-                    await self._broadcast_devices()
+                # Cleanup stale entries
+                self._rssi_cleanup()
+
             except asyncio.CancelledError:
                 return
             except Exception as e:
-                logger.debug("RSSI poll error: %s", e)
+                logger.debug("RSSI refresh error: %s", e)
+
+    def _rssi_cleanup(self) -> None:
+        """Remove stale RSSI entries for devices no longer visible."""
+        changed = False
+        for addr in list(self._connected_rssi):
+            if addr in self.managed_devices:
+                continue
+            if addr in self._device_connect_time:
+                continue
+            del self._connected_rssi[addr]
+            changed = True
+        if changed:
+            asyncio.ensure_future(self._broadcast_devices())
 
     # -- SSE broadcast helpers --
 

--- a/src/bt_audio_manager/manager.py
+++ b/src/bt_audio_manager/manager.py
@@ -1610,6 +1610,11 @@ class BluetoothAudioManager:
         BlueZ sends RSSI updates on org.bluez.Device1 during discovery
         scanning.  We capture these instead of discarding them so the
         frontend can show signal strength.
+
+        During user-initiated scans (_scanning=True), RSSI is cached for
+        any device.  During silent refresh bursts, only devices we're
+        tracking (connected or managed) are cached to avoid UI churn
+        from random nearby devices in RF-dense environments.
         """
         try:
             rssi = rssi_variant.value if hasattr(rssi_variant, "value") else int(rssi_variant)
@@ -1620,6 +1625,10 @@ class BluetoothAudioManager:
         if len(parts) < 2 or not parts[1].startswith("dev_"):
             return
         address = parts[1][4:].replace("_", ":").upper()
+        # During silent refresh bursts, only track devices we care about
+        if not self._scanning:
+            if address not in self._device_connect_time and address not in self.managed_devices:
+                return
         prev = self._connected_rssi.get(address)
         self._connected_rssi[address] = rssi
         # Broadcast only on significant change (>=3 dBm) or None→value transition
@@ -1656,6 +1665,9 @@ class BluetoothAudioManager:
                     await asyncio.sleep(self.RSSI_REFRESH_DURATION)
                 finally:
                     await self.adapter.stop_rssi_refresh()
+                    # Clear logged-device cache to prevent unbounded growth
+                    # from rotating BLE addresses in RF-dense environments
+                    self.adapter.clear_logged_cache()
 
                 # Cleanup stale entries
                 self._rssi_cleanup()


### PR DESCRIPTION
## Summary
- hcitool cannot work inside HA add-on containers (no host Bluetooth network namespace)
- Replace with periodic silent discovery bursts (5s every 60s) that refresh RSSI via D-Bus PropertiesChanged without triggering UI scan activity
- Revert `bluez-deprecated` package addition and all hcitool code
- Add `adapter.start_rssi_refresh()`/`stop_rssi_refresh()` — runs StartDiscovery without log cache clear or `_discovering` flag
- `_scanning` stays False during bursts so no UI events fire
- Also reverts the hcitool-specific AppArmor comment changes from #233

## Test plan
- [ ] Connect a BT audio device, wait ~60s, verify RSSI appears in UI
- [ ] Verify no "device discovered" log spam during refresh bursts
- [ ] Trigger a manual scan while refresh is running — verify no conflict
- [ ] Disconnect device — verify RSSI clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)