### PR TITLE
Stabilize device tiles during scan

### DIFF
--- a/src/bt_audio_manager/web/static/app.js
+++ b/src/bt_audio_manager/web/static/app.js
@@ -494,9 +494,10 @@ function renderDevices(devices) {
         }
       }
 
+      const staleClass = d._stale ? " device-stale" : "";
       return `
         <div class="col-md-6 col-lg-4">
-          <div class="card device-card h-100">
+          <div class="card device-card h-100${staleClass}">
             <div class="card-body">
               <div class="d-flex justify-content-between align-items-start mb-2">
                 <h5 class="card-title mb-0" title="${escapeHtml(d.name)}">${escapeHtml(d.name)}</h5>
@@ -1276,24 +1277,93 @@ function connectWebSocket() {
 }
 
 // Cache last known devices for re-rendering when sinks change
-let lastDevices = null;
+let lastDevices = null;    // Final merged+sorted list (includes stale)
+let _lastRawDevices = null; // Raw devices from server (no stale entries)
 
 function refreshDevicesFromCache() {
-  if (lastDevices) {
-    renderDevices(lastDevices);
+  if (_lastRawDevices) {
+    renderDevices(_lastRawDevices);
   }
 }
 
-// Wrap renderDevices to cache
-const _origRenderDevices = renderDevices;
-// We need to intercept — override via reassignment pattern
+// --- Debounced removal & stable sort ---
+// Track last-seen timestamps and full device data for graceful fade-out
+const _deviceLastSeen = new Map();   // address -> timestamp (ms)
+const _deviceCache = new Map();      // address -> device object (last known state)
+const DEVICE_STALE_MS = 20000;       // Keep disappeared devices visible for 20s
+let _staleCleanupTimer = null;
+
+function _sortDevicesStable(devices) {
+  // Priority: connected (0) > paired/stored (1) > discovered (2), then by address
+  const priority = (d) => d.connected ? 0 : (d.paired || d.stored) ? 1 : 2;
+  return devices.slice().sort((a, b) => {
+    const pa = priority(a), pb = priority(b);
+    if (pa !== pb) return pa - pb;
+    return a.address.localeCompare(b.address);
+  });
+}
+
+// Wrap renderDevices to cache, debounce removal, and stabilize sort order
 (function () {
-  const grid = null; // Will be resolved at call time
   const origFn = renderDevices;
 
   window.renderDevices = function (devices) {
-    lastDevices = devices;
-    origFn(devices);
+    const now = Date.now();
+    const currentAddresses = new Set();
+
+    // Save raw (non-stale) devices for refreshDevicesFromCache
+    _lastRawDevices = devices;
+
+    // Update last-seen and cache for all devices in this update
+    if (devices) {
+      for (const d of devices) {
+        currentAddresses.add(d.address);
+        _deviceLastSeen.set(d.address, now);
+        _deviceCache.set(d.address, d);
+      }
+    }
+
+    // Merge in stale devices that disappeared recently (discovered-only, not paired/connected)
+    const merged = devices ? [...devices] : [];
+    const mergedAddresses = new Set(currentAddresses);
+
+    for (const [addr, lastSeen] of _deviceLastSeen) {
+      if (mergedAddresses.has(addr)) continue;
+      const age = now - lastSeen;
+      if (age < DEVICE_STALE_MS) {
+        const cached = _deviceCache.get(addr);
+        if (cached && !cached.paired && !cached.stored && !cached.connected) {
+          // Mark as stale so the renderer can dim it
+          merged.push({ ...cached, _stale: true });
+          mergedAddresses.add(addr);
+        }
+      } else {
+        // Expired — clean up
+        _deviceLastSeen.delete(addr);
+        _deviceCache.delete(addr);
+      }
+    }
+
+    // Stable sort so tiles don't jump around
+    const sorted = _sortDevicesStable(merged);
+
+    lastDevices = sorted;
+    origFn(sorted);
+
+    // Schedule cleanup to remove stale devices after they expire
+    if (!_staleCleanupTimer) {
+      _staleCleanupTimer = setInterval(() => {
+        const hasStale = [..._deviceLastSeen.entries()].some(
+          ([addr, ts]) => !lastDevices?.find((d) => d.address === addr && !d._stale) && Date.now() - ts < DEVICE_STALE_MS
+        );
+        if (hasStale) {
+          refreshDevicesFromCache();
+        } else {
+          clearInterval(_staleCleanupTimer);
+          _staleCleanupTimer = null;
+        }
+      }, 5000);
+    }
   };
 })();
 

--- a/src/bt_audio_manager/web/static/app.js
+++ b/src/bt_audio_manager/web/static/app.js
@@ -1353,12 +1353,14 @@ function _sortDevicesStable(devices) {
     // Schedule cleanup to remove stale devices after they expire
     if (!_staleCleanupTimer) {
       _staleCleanupTimer = setInterval(() => {
+        // Check if any stale entries remain (not yet expired)
+        const now = Date.now();
         const hasStale = [..._deviceLastSeen.entries()].some(
-          ([addr, ts]) => !lastDevices?.find((d) => d.address === addr && !d._stale) && Date.now() - ts < DEVICE_STALE_MS
+          ([addr, ts]) => !_lastRawDevices?.find((d) => d.address === addr) && now - ts < DEVICE_STALE_MS
         );
-        if (hasStale) {
-          refreshDevicesFromCache();
-        } else {
+        // Always re-render to flush out just-expired entries
+        refreshDevicesFromCache();
+        if (!hasStale) {
           clearInterval(_staleCleanupTimer);
           _staleCleanupTimer = null;
         }

--- a/src/bt_audio_manager/web/static/style.css
+++ b/src/bt_audio_manager/web/static/style.css
@@ -343,6 +343,12 @@ h1, h2, h3, h4, h5, h6 {
   box-shadow: var(--shadow-card-hover);
 }
 
+.device-card.device-stale {
+  opacity: 0.45;
+  pointer-events: none;
+  transition: opacity 0.6s ease;
+}
+
 .device-card .card-title {
   font-size: 1rem;
   font-weight: 600;


### PR DESCRIPTION
## Summary
- **Debounced removal**: Discovered devices that drop out of scan results fade to 45% opacity for 20s instead of vanishing instantly, preventing layout shifts and misclicks
- **Stable sort order**: Tiles sorted connected > paired > discovered, then by MAC address — positions don't jump as devices appear/disappear
- Stale tiles are non-interactive (`pointer-events: none`) so they can't be accidentally clicked

## Test plan
- [ ] Start a scan with weak-signal devices nearby — verify tiles fade instead of vanishing when signal drops
- [ ] Verify faded tiles disappear after ~20s
- [ ] Verify connected/paired devices are always at the top, new discovered devices append below
- [ ] Verify clicking pair/disconnect still works on non-stale tiles
- [ ] Verify stale (faded) tiles cannot be clicked

🤖 Generated with [Claude Code](https://claude.com/claude-code)