### PR TITLE
Fix RSSI refresh re-logging all devices every 60s

### DIFF
--- a/src/bt_audio_manager/bluez/adapter.py
+++ b/src/bt_audio_manager/bluez/adapter.py
@@ -166,6 +166,15 @@ class BluezAdapter:
         """Clear the per-scan device log cache to prevent unbounded growth."""
         self._logged_cache.clear()
 
+    def trim_logged_cache(self, max_size: int = 200) -> None:
+        """Trim the log cache if it has grown too large (rotating BLE addresses).
+
+        Unlike clear_logged_cache(), this preserves most entries so that
+        subsequent get_audio_devices() calls don't re-log every device.
+        """
+        if len(self._logged_cache) > max_size:
+            self._logged_cache.clear()
+
     async def get_audio_devices(self, *, cod_fallback: bool = False) -> list[dict]:
         """Enumerate discovered devices that can receive/play audio.
 

--- a/src/bt_audio_manager/manager.py
+++ b/src/bt_audio_manager/manager.py
@@ -1665,9 +1665,11 @@ class BluetoothAudioManager:
                     await asyncio.sleep(self.RSSI_REFRESH_DURATION)
                 finally:
                     await self.adapter.stop_rssi_refresh()
-                    # Clear logged-device cache to prevent unbounded growth
-                    # from rotating BLE addresses in RF-dense environments
-                    self.adapter.clear_logged_cache()
+                    # Trim (don't clear) logged-device cache to prevent
+                    # unbounded growth from rotating BLE addresses while
+                    # preserving entries so get_audio_devices() doesn't
+                    # re-log every device after each RSSI burst
+                    self.adapter.trim_logged_cache()
 
                 # Cleanup stale entries
                 self._rssi_cleanup()


### PR DESCRIPTION
## Summary
- After each silent RSSI discovery burst, `clear_logged_cache()` was wiping the "already logged" set, causing `get_audio_devices()` to re-log all 40+ skipped devices at INFO level every 60 seconds
- Replace with `trim_logged_cache()` that only clears when the set exceeds 200 entries (rotating BLE addresses), preserving entries between bursts
- User-initiated scans still clear the cache fully for fresh output

## Test plan
- [ ] Verify logs no longer show "Skipping device" spam every ~60s during idle operation
- [ ] Verify user-initiated scan still logs all discovered/skipped devices
- [ ] Verify RSSI signal strength still updates on the UI for connected devices

🤖 Generated with [Claude Code](https://claude.com/claude-code)