### PR TITLE
Downgrade 'Skipping device' log from INFO to DEBUG

### DIFF
--- a/src/bt_audio_manager/bluez/adapter.py
+++ b/src/bt_audio_manager/bluez/adapter.py
@@ -236,7 +236,7 @@ class BluezAdapter:
                         f"0x{cod_raw:06X}({cod_major_label(cod_raw)})"
                         if cod_raw else "(none)"
                     )
-                    logger.info(
+                    logger.debug(
                         "Skipping device %s (%s) — %s. UUIDs: %s CoD: %s",
                         name, addr, reason,
                         sorted(uuids) if uuids else "(none)",


### PR DESCRIPTION
## Summary
- Per-device "Skipping device" rejection logs downgraded from INFO to DEBUG
- These lines (30-50 per call) flood the log panel on every `get_audio_devices()` invocation — startup RSSI burst, WS client connect, user scans
- The INFO-level summary line (`get_audio_devices: N objects scanned, M skipped, K matched`) still provides sufficient visibility
- "Accepted device" logs remain at INFO

## Test plan
- [ ] Verify "Skipping device" lines no longer appear in the add-on log panel at default log level
- [ ] Verify summary line still appears: `get_audio_devices: N objects scanned, M skipped, K matched`
- [ ] Verify "Accepted device" lines still appear at INFO
- [ ] Verify skipped device details are visible when log level is set to DEBUG

🤖 Generated with [Claude Code](https://claude.com/claude-code)