### PR TITLE
Reserve badge row height for consistent card alignment

### DIFF
--- a/src/bt_audio_manager/web/static/app.js
+++ b/src/bt_audio_manager/web/static/app.js
@@ -321,9 +321,7 @@ function buildCapBadges(device) {
       badges.push('<span class="cap-badge bg-warning text-dark" title="Media buttons disabled">AVRCP \u2717</span>');
     }
   }
-  return badges.length > 0
-    ? `<div class="d-flex flex-wrap gap-1 mb-1">${badges.join("")}</div>`
-    : "";
+  return `<div class="d-flex flex-wrap gap-1 mb-1 cap-badge-row">${badges.join("")}</div>`;
 }
 
 function buildFeatureBadges(device) {

--- a/src/bt_audio_manager/web/static/style.css
+++ b/src/bt_audio_manager/web/static/style.css
@@ -450,6 +450,11 @@ h1, h2, h3, h4, h5, h6 {
   text-align: center;
 }
 
+/* Badge row — reserve height even when empty so cards align */
+.cap-badge-row {
+  min-height: 1.1rem;
+}
+
 /* Active capability badges on device cards */
 .cap-badge {
   font-size: 0.65rem;


### PR DESCRIPTION
## Summary
- Always render the capability badge wrapper div (even when empty) with `min-height: 1.1rem`
- MAC addresses and content below badges now align across cards when one has BR/EDR/A2DP badges and another has none

## Test plan
- [ ] Verify connected device card with badges and discovered device card without badges have aligned MAC address lines
- [ ] Verify badges still render correctly when present

🤖 Generated with [Claude Code](https://claude.com/claude-code)