### PR TITLE
Show capability badges on discovered devices

### DIFF
--- a/src/bt_audio_manager/web/static/app.js
+++ b/src/bt_audio_manager/web/static/app.js
@@ -285,39 +285,43 @@ function profileLabels(uuids) {
 }
 
 function buildCapBadges(device) {
-  if (!device.connected) {
-    return '<div class="d-flex flex-wrap gap-1 mb-1"><span class="cap-badge" style="visibility:hidden">\u00A0</span></div>';
-  }
   const badges = [];
+  const connected = device.connected;
   // Bearer type (BR/EDR, LE)
   if (device.bearers) {
     for (const b of device.bearers) {
       badges.push(`<span class="cap-badge bg-secondary" title="${b === "BR/EDR" ? "Classic Bluetooth" : "Bluetooth Low Energy"}">${escapeHtml(b)}</span>`);
     }
   }
-  // Audio profile badges — show selected profile with checkmark
+  // Audio profile badges — checkmarks only when connected
   const uuids = (device.uuids || []).map((u) => u.toLowerCase());
   const activeProfile = device.audio_profile || "a2dp";
   const hasA2dpSink = uuids.some((u) => u.startsWith("0000110b"));
   const hasHfpHsp = uuids.some((u) => u.startsWith("0000111e") || u.startsWith("00001108"));
   if (hasA2dpSink) {
-    if (window._hfpSwitchingEnabled && activeProfile !== "a2dp") {
+    if (!connected) {
+      badges.push('<span class="cap-badge bg-info" title="A2DP stereo audio available">A2DP</span>');
+    } else if (window._hfpSwitchingEnabled && activeProfile !== "a2dp") {
       badges.push('<span class="cap-badge bg-info" title="A2DP stereo audio available">A2DP</span>');
     } else {
       badges.push('<span class="cap-badge bg-success" title="A2DP stereo audio (active)">A2DP \u2713</span>');
     }
   }
-  if (window._hfpSwitchingEnabled && hasHfpHsp) {
-    if (activeProfile === "hfp") {
+  if (hasHfpHsp) {
+    if (!connected) {
+      badges.push('<span class="cap-badge bg-info" title="Hands-Free / Headset Profile available">HFP</span>');
+    } else if (window._hfpSwitchingEnabled && activeProfile === "hfp") {
       badges.push('<span class="cap-badge bg-success" title="HFP/HSP mono + mic (active)">HFP \u2713</span>');
-    } else {
+    } else if (window._hfpSwitchingEnabled) {
       badges.push('<span class="cap-badge bg-info" title="Hands-Free / Headset Profile available">HFP</span>');
     }
   }
   // AVRCP
   const hasAvrcp = uuids.some((u) => u.startsWith("0000110c") || u.startsWith("0000110e"));
   if (hasAvrcp) {
-    if (device.avrcp_enabled !== false) {
+    if (!connected) {
+      badges.push('<span class="cap-badge bg-info" title="AVRCP media control available">AVRCP</span>');
+    } else if (device.avrcp_enabled !== false) {
       badges.push('<span class="cap-badge bg-success" title="Media buttons enabled">AVRCP \u2713</span>');
     } else {
       badges.push('<span class="cap-badge bg-warning text-dark" title="Media buttons disabled">AVRCP \u2717</span>');

--- a/src/bt_audio_manager/web/static/app.js
+++ b/src/bt_audio_manager/web/static/app.js
@@ -285,7 +285,9 @@ function profileLabels(uuids) {
 }
 
 function buildCapBadges(device) {
-  if (!device.connected) return "";
+  if (!device.connected) {
+    return '<div class="d-flex flex-wrap gap-1 mb-1"><span class="cap-badge" style="visibility:hidden">\u00A0</span></div>';
+  }
   const badges = [];
   // Bearer type (BR/EDR, LE)
   if (device.bearers) {


### PR DESCRIPTION
## Summary
- Discovered devices with audio UUIDs now show A2DP, HFP, AVRCP badges in blue (available but not active)
- Connected devices keep green checkmarks (active) / yellow (disabled)
- Devices with no UUIDs (CoD-only fallback) get a hidden badge spacer for alignment
- Fixes badge spacer not rendering for non-connected devices (early return bypassed spacer logic)

## Test plan
- [ ] Scan and discover a device with audio UUIDs — verify blue A2DP/HFP badges appear
- [ ] Verify connected device still shows green checkmark badges
- [ ] Verify CoD-only device (no UUIDs) has aligned MAC address via hidden spacer
- [ ] Verify MAC addresses align across all card types

🤖 Generated with [Claude Code](https://claude.com/claude-code)