### PR TITLE
fix(mpd): use software mixer so volume is always exposed (#274)

### DIFF
--- a/bluetooth_audio_manager/config.yaml
+++ b/bluetooth_audio_manager/config.yaml
@@ -1,5 +1,5 @@
 name: "Bluetooth Audio Manager"
-version: "2.0.0"
+version: "2.0.1"
 slug: bluetooth_audio_manager
 description: "Manage Bluetooth audio device connections (A2DP) with persistent pairing, auto-reconnect, and AppArmor security."
 url: "https://github.com/scyto/ha-bluetooth-audio-manager"

--- a/src/bt_audio_manager/audio/mpd.py
+++ b/src/bt_audio_manager/audio/mpd.py
@@ -125,6 +125,12 @@ class MPDManager:
                 type    "pulse"
                 name    "{speaker_name}"
                 sink    "{sink}"
+                # software mixer is always "online", so MPD always reports a
+                # "volume" field — even when stopped. The pulse mixer (MPD's
+                # default for this plugin) only reports volume while a
+                # sink-input exists (i.e. during playback), so HA's MPD
+                # integration would hide the volume slider whenever idle. (#274)
+                mixer_type    "software"
             }}
 
             input {{


### PR DESCRIPTION
## Summary

Fixes #274 — the MPD `media_player` exposes no volume slider and `media_player.volume_set` is a no-op.

**Root cause:** MPD's `pulse` output already gets a mixer by default (global default `mixer_type` is `hardware` and the pulse plugin provides one), but that pulse mixer is *per-output* — it only reports a volume while a PulseAudio sink-input exists, i.e. during active playback. When MPD is stopped it goes offline, `status` omits `volume:`, and HA's MPD integration (which gates `VOLUME_SET` on the presence of that field) hides the slider. The issue's suggested `mixer_type "hardware"` would have been a no-op (it just restates the default).

**Fix:** use the **software** mixer, which is *global* (always online) and always reports a volume regardless of play state. Digital attenuation is fine here since the A2DP stream is re-encoded downstream.

## Changes

- `src/bt_audio_manager/audio/mpd.py` — add `mixer_type "software"` to the generated `audio_output` block.
- `bluetooth_audio_manager/config.yaml` — bump stable version `2.0.0` → `2.0.1`.

## ⚠️ Draft — do not merge until verified

Held as a draft pending @annimesh2809 confirming the dev build (`ghcr.io/scyto/ha-bluetooth-audio-manager-dev:sha-c6de22e`) on their Divoom Ditoo Pro — see the discussion in #274.

## Release steps (after marking ready + merging)

The Supervisor pulls `ghcr.io/scyto/ha-bluetooth-audio-manager:<version>`, so the image tag is driven by `config.yaml`. Merge, then **immediately** tag to build the matching image (there's a brief window where `main` advertises 2.0.1 before the image exists):

```
git tag v2.0.1 && git push origin v2.0.1
```

That triggers the stable build → publishes `:2.0.1` + `:latest`, and HA offers the update.
