### PR TITLE
fix: normalize MPD stream volume on creation

### DIFF
--- a/src/bt_audio_manager/audio/pulse.py
+++ b/src/bt_audio_manager/audio/pulse.py
@@ -201,9 +201,9 @@ class PulseAudioManager:
                     await _pe.connect()
                 try:
                     retry_delay = 2  # reset on successful connection
-                    logger.info("PA event subscription started (sink events)")
-                    async for event in _pe.subscribe_events("sink", "server"):
-                        if event.t == "change" and self._pulse:
+                    logger.info("PA event subscription started (sink and sink-input events)")
+                    async for event in _pe.subscribe_events("sink", "sink_input", "server"):
+                        if event.facility == "sink" and event.t == "change" and self._pulse:
                             try:
                                 sink = await self._pulse.sink_info(event.index)
                                 if "bluez" in sink.name.lower():
@@ -228,8 +228,10 @@ class PulseAudioManager:
                                             self._idle_callback(sink.name)
                             except Exception as e:
                                 logger.debug("PA event handler error: %s", e)
-                        elif event.t in ("new", "remove"):
+                        elif event.facility == "sink" and event.t in ("new", "remove"):
                             logger.info("PA sink %s: index=%d", event.t, event.index)
+                        elif event.facility == "sink_input" and event.t == "new":
+                            await self._normalize_new_mpd_stream(event.index)
                 finally:
                     _pe.close()
             except asyncio.CancelledError:
@@ -538,6 +540,34 @@ class PulseAudioManager:
             logger.warning("Sink not found for resume: %s", sink_name)
         except Exception as e:
             logger.warning("Failed to resume sink %s: %s", sink_name, e)
+        return False
+
+    async def _normalize_new_mpd_stream(self, stream_index: int) -> bool:
+        """Set a newly-created MPD stream to full volume on a Bluetooth sink.
+
+        MPD uses a software mixer, so its PulseAudio stream must stay at full
+        volume. PulseAudio's ``module-stream-restore`` can otherwise restore
+        a stale per-role volume for ``media.role=music`` when the stream is
+        created, causing attenuation that MPD and Home Assistant cannot see.
+        """
+        if not self._pulse:
+            return False
+        try:
+            stream = await self._pulse.sink_input_info(stream_index)
+            props = getattr(stream, "proplist", {})
+            if (
+                props.get("application.name") != "Music Player Daemon"
+                or props.get("application.process.binary") != "mpd"
+            ):
+                return False
+            sink = await self._pulse.sink_info(stream.sink)
+            if not sink.name.lower().startswith("bluez_sink."):
+                return False
+            await self._pulse.volume_set_all_chans(stream, 1.0)
+            logger.info("MPD stream volume set to 100%% on %s", sink.name)
+            return True
+        except Exception as e:
+            logger.debug("Failed to normalize new MPD stream %d: %s", stream_index, e)
         return False
 
     async def set_sink_volume(self, sink_name: str, volume_pct: int) -> bool:

--- a/tests/test_pulse.py
+++ b/tests/test_pulse.py
@@ -1,0 +1,107 @@
+import unittest
+from types import SimpleNamespace
+
+from bt_audio_manager.audio.pulse import PulseAudioManager
+
+
+class FakePulse:
+    def __init__(self, sinks, sink_inputs, event_stream):
+        self._sinks = sinks
+        self._sink_inputs = sink_inputs
+        self._event_stream = event_stream
+        self.volume_calls = []
+
+    async def sink_input_info(self, index):
+        return self._event_stream
+
+    async def sink_info(self, index):
+        return next(sink for sink in self._sinks if sink.index == index)
+
+    async def volume_set_all_chans(self, sink_input, volume):
+        self.volume_calls.append((sink_input.index, volume))
+
+
+class TestMpdStreamNormalization(unittest.IsolatedAsyncioTestCase):
+    async def test_normalizes_exact_new_mpd_stream_when_another_mpd_stream_exists(self):
+        sink = SimpleNamespace(index=7, name="bluez_sink.6C_0D_C4_30_50_F6.a2dp_sink")
+        old_mpd_stream = SimpleNamespace(
+            index=101,
+            sink=7,
+            proplist={
+                "application.name": "Music Player Daemon",
+                "application.process.binary": "mpd",
+            },
+        )
+        new_mpd_stream = SimpleNamespace(
+            index=102,
+            sink=7,
+            proplist={
+                "application.name": "Music Player Daemon",
+                "application.process.binary": "mpd",
+            },
+        )
+        pulse = PulseAudioManager()
+        pulse._pulse = FakePulse([sink], [old_mpd_stream, new_mpd_stream], new_mpd_stream)
+
+        updated = await pulse._normalize_new_mpd_stream(new_mpd_stream.index)
+
+        self.assertTrue(updated)
+        self.assertEqual(pulse._pulse.volume_calls, [(new_mpd_stream.index, 1.0)])
+
+    async def test_skips_mpd_stream_on_non_bluetooth_sink(self):
+        sink = SimpleNamespace(index=7, name="alsa_output.pci-0000_00_1f.3.analog-stereo")
+        mpd_stream = SimpleNamespace(
+            index=101,
+            sink=7,
+            proplist={
+                "application.name": "Music Player Daemon",
+                "application.process.binary": "mpd",
+            },
+        )
+        pulse = PulseAudioManager()
+        pulse._pulse = FakePulse([sink], [mpd_stream], mpd_stream)
+
+        updated = await pulse._normalize_new_mpd_stream(mpd_stream.index)
+
+        self.assertFalse(updated)
+        self.assertEqual(pulse._pulse.volume_calls, [])
+
+    async def test_skips_sink_with_bluez_only_in_its_name(self):
+        sink = SimpleNamespace(index=7, name="combined_bluez_sink")
+        mpd_stream = SimpleNamespace(
+            index=101,
+            sink=7,
+            proplist={
+                "application.name": "Music Player Daemon",
+                "application.process.binary": "mpd",
+            },
+        )
+        pulse = PulseAudioManager()
+        pulse._pulse = FakePulse([sink], [mpd_stream], mpd_stream)
+
+        updated = await pulse._normalize_new_mpd_stream(mpd_stream.index)
+
+        self.assertFalse(updated)
+        self.assertEqual(pulse._pulse.volume_calls, [])
+
+    async def test_skips_non_mpd_stream_on_bluetooth_sink(self):
+        sink = SimpleNamespace(index=7, name="bluez_sink.6C_0D_C4_30_50_F6.a2dp_sink")
+        music_stream = SimpleNamespace(
+            index=101,
+            sink=7,
+            proplist={
+                "application.name": "Another music player",
+                "application.process.binary": "other-player",
+            },
+        )
+        pulse = PulseAudioManager()
+        pulse._pulse = FakePulse([sink], [music_stream], music_stream)
+
+        updated = await pulse._normalize_new_mpd_stream(music_stream.index)
+
+        self.assertFalse(updated)
+        self.assertEqual(pulse._pulse.volume_calls, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- normalize each newly-created MPD PulseAudio stream to 100% when it targets a Bluetooth sink
- preserve MPD's software mixer as the single user-facing volume control
- prevent PulseAudio `module-stream-restore` from applying a stale `media.role=music` attenuation that Home Assistant and MPD cannot report

The normalization is scoped to the exact `sink_input` that raised the PulseAudio `sink_input/new` event. It requires both MPD properties (`application.name` and `application.process.binary`) and a `bluez_sink.` destination, so other applications and non-Bluetooth sinks are not modified.

## Test plan

- `PYTHONPATH=src .venv/bin/python -m unittest discover -s tests -v`
- `PYTHONPATH=src .venv/bin/python -m compileall -q src tests`

The new tests cover the case where multiple MPD inputs coexist on the same Bluetooth sink, plus non-Bluetooth, non-MPD, and non-`bluez_sink.` negative cases.
