### PR TITLE
Devices advertising non-standard/vendor UUIDs (e.g. Anker Soundcore) skipped despite correct Class of Device

### DIFF
--- a/src/bt_audio_manager/bluez/adapter.py
+++ b/src/bt_audio_manager/bluez/adapter.py
@@ -215,15 +215,20 @@ class BluezAdapter:
 
             uuid_matched = bool(uuids.intersection(SINK_UUIDS))
 
-            # CoD fallback (scan-only): device advertises no UUIDs but
-            # has an audio-sink CoD (headphones, speaker, etc.).  These
-            # are budget BR/EDR devices that only expose profiles after
-            # pairing triggers SDP.  Gated to cod_fallback=True to avoid
-            # surfacing stale BlueZ cache entries as ghost devices.
+            # CoD fallback (scan-only): device doesn't match a known sink
+            # UUID but has an audio-sink CoD (headphones, speaker, etc.).
+            # Covers two cases: (a) budget BR/EDR devices that advertise
+            # no UUIDs at all until pairing triggers SDP, and (b) devices
+            # that advertise UUIDs, but only non-standard/vendor-specific
+            # ones (e.g. Anker Soundcore's proprietary PartyCast UUID)
+            # rather than the standard A2DP Sink UUID. In both cases the
+            # CoD alone is sufficient to identify the device as a
+            # speaker per the Bluetooth spec.  Gated to cod_fallback=True
+            # to avoid surfacing stale BlueZ cache entries as ghost
+            # devices.
             cod_matched = (
                 cod_fallback
                 and not uuid_matched
-                and not uuids
                 and is_cod_audio_sink(cod_raw)
             )
 
@@ -282,10 +287,13 @@ class BluezAdapter:
                 else:
                     state = "unpaired"
                 if cod_matched:
+                    uuid_note = (
+                        "UUIDs will resolve after pairing." if not uuids
+                        else f"non-standard UUIDs advertised: {sorted(uuids)}."
+                    )
                     logger.info(
-                        "Accepted device %s (%s) [%s] — CoD fallback %s. "
-                        "UUIDs will resolve after pairing.",
-                        name, addr, state, cod_str,
+                        "Accepted device %s (%s) [%s] — CoD fallback %s. %s",
+                        name, addr, state, cod_str, uuid_note,
                     )
                 else:
                     matched = sorted(uuids.intersection(SINK_UUIDS))


### PR DESCRIPTION
## Problem

Devices advertising non-standard/vendor-specific UUIDs (e.g. Anker Soundcore's
proprietary PartyCast UUID) are skipped during discovery even when their
Class of Device (CoD) unambiguously identifies them as an audio sink.

Example from a scan log:

Skipping device Soundcore 3 (F4:4E:FC:77:03:83) — no audio sink profile.
UUIDs: ['00000000-deca-fade-deca-deafdecacaff'] CoD: 0x240414(Audio/Video)

CoD 0x240414 is an unambiguous Audio/Video speaker classification, but the
device was still skipped because it advertises a non-standard UUID rather
than the expected A2DP Sink UUID (0000110b-...).

## Root cause

The existing CoD fallback in `get_audio_devices()` only triggers when a
device advertises **zero** UUIDs at all:

    cod_matched = (
        cod_fallback
        and not uuid_matched
        and not uuids          # <-- required no UUIDs whatsoever
        and is_cod_audio_sink(cod_raw)
    )

This covers budget devices with no SDP info pre-pairing, but not devices
that advertise some UUIDs, just non-matching/vendor-specific ones.

## Fix

Removed the `and not uuids` condition so the fallback triggers whenever
standard UUID matching fails, regardless of whether non-matching UUIDs
are present. Also updated the adjacent doc comment and the "Accepted
device" log message so it stays accurate for this new case.

## Testing

Verified the modified file compiles cleanly (`python -m py_compile`).
I wasn't able to live-test inside the running add-on container due to
its AppArmor profile blocking introspection (`/proc` and `pip` access
both denied under `docker exec`) — which is a sign the add-on's security
posture is working as intended, just not conducive to this kind of
local verification. Happy to test further if there's a lower-friction
way to do so.

## Attribution
Claude for the investigation.
CoPi for the code and GitHubbery.