### PR TITLE
fix(discovery): apply CoD fallback to vendor-only UUID advertisers

### DIFF
--- a/src/bt_audio_manager/bluez/adapter.py
+++ b/src/bt_audio_manager/bluez/adapter.py
@@ -11,6 +11,7 @@ from dbus_next.errors import DBusError
 from .constants import (
     A2DP_SOURCE_UUID,
     ADAPTER_INTERFACE,
+    AUDIO_UUIDS,
     AVRCP_CONTROLLER_UUID,
     AVRCP_TARGET_UUID,
     BLUEZ_SERVICE,
@@ -188,10 +189,10 @@ class BluezAdapter:
         HFP, or HSP).  Devices that only advertise A2DP Source (e.g.
         phones) are excluded since this add-on manages speakers.
 
-        When cod_fallback=True, devices with no UUIDs but an audio-sink
-        Class of Device are also accepted.  This should only be enabled
-        during scan sessions to avoid surfacing stale BlueZ cache entries
-        as ghost devices.
+        When cod_fallback=True, devices that advertise no recognised audio
+        UUID but have an audio-sink Class of Device are also accepted.
+        This should only be enabled during scan sessions to avoid
+        surfacing stale BlueZ cache entries as ghost devices.
         """
         introspection = await self._bus.introspect(BLUEZ_SERVICE, "/")
         proxy = self._bus.get_proxy_object(BLUEZ_SERVICE, "/", introspection)
@@ -215,15 +216,26 @@ class BluezAdapter:
 
             uuid_matched = bool(uuids.intersection(SINK_UUIDS))
 
-            # CoD fallback (scan-only): device advertises no UUIDs but
-            # has an audio-sink CoD (headphones, speaker, etc.).  These
-            # are budget BR/EDR devices that only expose profiles after
-            # pairing triggers SDP.  Gated to cod_fallback=True to avoid
-            # surfacing stale BlueZ cache entries as ghost devices.
+            # CoD fallback (scan-only): device advertises nothing we
+            # recognise as an audio profile, but has an audio-sink CoD
+            # (headphones, speaker, etc.).  Pre-pairing, Device1.UUIDs
+            # comes from the inquiry-response EIR rather than SDP, so it
+            # is either empty (budget BR/EDR devices that only expose
+            # profiles once pairing triggers SDP) or carries whatever the
+            # vendor chose to broadcast — e.g. Anker Soundcore advertises
+            # only Apple's iAP2/MFi accessory UUID.  Both cases are "no
+            # profile information", so fall back to the CoD.
+            #
+            # Devices that DO advertise a recognised audio UUID are left
+            # alone: A2DP Source (phones, projectors, TVs), AVRCP-only
+            # remotes and LE Audio devices all still fall through to
+            # their own rejection branches in _classify_rejection().
+            # Gated to cod_fallback=True to avoid surfacing stale BlueZ
+            # cache entries as ghost devices.  (#286)
             cod_matched = (
                 cod_fallback
                 and not uuid_matched
-                and not uuids
+                and not uuids.intersection(AUDIO_UUIDS)
                 and is_cod_audio_sink(cod_raw)
             )
 
@@ -282,10 +294,14 @@ class BluezAdapter:
                 else:
                     state = "unpaired"
                 if cod_matched:
+                    uuid_note = (
+                        f"unrecognised UUIDs advertised: {sorted(uuids)}."
+                        if uuids else "no UUIDs advertised."
+                    )
                     logger.info(
                         "Accepted device %s (%s) [%s] — CoD fallback %s. "
-                        "UUIDs will resolve after pairing.",
-                        name, addr, state, cod_str,
+                        "%s Audio profiles will resolve after pairing.",
+                        name, addr, state, cod_str, uuid_note,
                     )
                 else:
                     matched = sorted(uuids.intersection(SINK_UUIDS))


### PR DESCRIPTION
Implements the change requested on #287. Leaving that PR open until @x-u-x can verify this on their hardware.

## Problem

The Anker Soundcore 3 in #286 is skipped during scans despite an unambiguous speaker CoD:

```
Skipping device Soundcore 3 (F4:4E:FC:77:03:83) — no audio sink profile.
UUIDs: ['00000000-deca-fade-deca-deafdecacaff'] CoD: 0x240414(Audio/Video)
```

`0x240414` decodes to Major **Audio/Video**, Minor **5 = Loudspeaker**, service bits **Rendering + Audio** — exactly what A2DP v1.4.1 §5.5.1 requires of a SNK. BlueZ agrees, setting `Icon=audio-card` on the same device later in the log.

The single UUID is Apple's **iAP2/MFi accessory** service UUID, not an Anker-specific one (the `…cafe` variant is the iPhone side). Pre-pairing, `Device1.UUIDs` is populated from the inquiry-response EIR rather than SDP, and this speaker broadcasts MFi there instead of A2DP Sink. The existing CoD fallback required `not uuids`, so a device advertising *something* unrecognised never reached it.

## Fix

Trigger the fallback when no **recognised audio** UUID is present, rather than only when the list is empty:

```python
cod_matched = (
    cod_fallback
    and not uuid_matched
    and not uuids.intersection(AUDIO_UUIDS)
    and is_cod_audio_sink(cod_raw)
)
```

## Why not just drop the UUID check

`is_cod_audio_sink()` inspects only major/minor class, so removing the UUID condition entirely lets A2DP **Source** devices with an Audio/Video CoD through and makes the `"audio source only"` branch of `_classify_rejection()` dead code for every AV-major device during scans.

The reporter's own scan log contains one: `Nebula-440001-M3V1` (`7C:E9:13:5E:B2:BB`), CoD `0x2C0404` → major 4, minor 1, advertising A2DP Source + AVRCP and no sink. `is_cod_audio_sink(0x2C0404)` returns `True`, so it would have been surfaced as a pairable speaker. This version keeps it rejected.

## Verification

Logic checked against every Audio/Video device in the #286 scan log plus the negative cases:

| device | UUIDs | CoD | surfaced |
|---|---|---|---|
| Soundcore 3 | iAP2/MFi only | `0x240414` | ✅ via CoD |
| Soundcore 3 (alt CoD seen in log) | iAP2/MFi only | `0x244414` | ✅ via CoD |
| DS1190 | none | `0x240404` | ✅ via CoD (unchanged) |
| Nebula projector | A2DP Source + AVRCP | `0x2C0404` | ❌ source only |
| QUIETPC | none | `0x2E4104` | ❌ not AV major |
| LE Audio speaker | PACS | `0x240414` | ❌ not yet supported |
| AVRCP-only remote | AVRCP | `0x240414` | ❌ no playback |
| normal speaker | A2DP Sink | `0x240414` | ✅ via UUID (unchanged) |

Not yet tested on hardware — needs @x-u-x to confirm the Soundcore 3 now appears and pairs.

Fixes #286
Supersedes #287