### PR TITLE
fix(mpd): give each MPD instance a private PulseAudio stream-restore entry

### DIFF
--- a/src/bt_audio_manager/audio/mpd.py
+++ b/src/bt_audio_manager/audio/mpd.py
@@ -170,6 +170,36 @@ class MPDManager:
         except Exception as e:
             logger.debug("Could not determine MPD version: %s", e)
 
+    def _daemon_env(self) -> dict[str, str]:
+        """Build the environment for the MPD subprocess.
+
+        Gives each MPD instance a private PulseAudio stream-restore entry.
+
+        MPD's pulse output plugin sets ``media.role=music`` on its stream
+        (it does its own ``setenv("PULSE_PROP_media.role", "music")``).
+        PulseAudio's ``module-stream-restore`` derives the key for its
+        saved per-stream volume from the proplist in a fixed order —
+        ``module-stream-restore.id``, then ``media.role``, then
+        application id/name (``pa_proplist_get_stream_group()``).  Role
+        wins, so every MPD instance would share the single
+        ``sink-input-by-media-role:music`` entry with every other
+        ``media.role=music`` client on HAOS's shared PulseAudio server:
+        HA's own players, Music Assistant, other add-ons.  Whatever
+        volume one of them last saved is then applied to our sink-input
+        at creation — invisible to both MPD and HA, because MPD's
+        software mixer is a separate layer from the PA stream volume.
+
+        Setting ``module-stream-restore.id`` per speaker takes precedence
+        over the role and isolates us from that shared entry.  libpulse
+        reads ``PULSE_PROP_<key>`` verbatim at context creation (key up
+        to the first '=', value is the rest, no unescaping), so the
+        hyphens in the key and the colons in the MAC are both safe.
+        (#285)
+        """
+        env = dict(os.environ)
+        env["PULSE_PROP_module-stream-restore.id"] = f"bt-audio-manager:{self._address}"
+        return env
+
     async def _start_daemon(self) -> None:
         """Start MPD in foreground mode as a subprocess."""
         await self._log_mpd_version()
@@ -177,6 +207,7 @@ class MPDManager:
             "mpd", "--no-daemon", "--stderr", self._conf_path,
             stdout=asyncio.subprocess.DEVNULL,
             stderr=asyncio.subprocess.PIPE,
+            env=self._daemon_env(),
         )
         # Give MPD a moment to initialize
         await asyncio.sleep(0.5)


### PR DESCRIPTION
Implements the alternative approach discussed on #285. Leaving that PR open until @slawa19 can verify this on their system.

## Problem

@slawa19's diagnosis on #285 is correct, and the sharing is wider than it first appears.

- HAOS loads `module-stream-restore` ([plugin-audio `rootfs/etc/pulse/system.pa:23`](https://github.com/home-assistant/plugin-audio/blob/master/rootfs/etc/pulse/system.pa)).
- MPD's pulse output does its own `setenv("PULSE_PROP_media.role", "music", true)` (`src/output/plugins/PulseOutputPlugin.cxx`), so every MPD stream carries `media.role=music`.
- `pa_proplist_get_stream_group()` (`src/pulsecore/proplist-util.c:265`) resolves the restore key in a fixed order: `module-stream-restore.id` → **`media.role`** → `application.id` → `application.name`. Role wins.

So our MPD streams never had a private restore entry — they shared `sink-input-by-media-role:music` with every other `media.role=music` client on HAOS's shared PulseAudio server: HA's own media players, Music Assistant, other add-ons. Whatever volume one of *those* last saved is applied to our sink-input at creation.

It's invisible from inside the stack: since #274 switched MPD to a software mixer, MPD no longer owns the PA stream volume, so neither MPD nor HA reports or corrects it. The user sees every slider at 100% and hears a quiet speaker.

## Fix

Because `module-stream-restore.id` is checked *ahead* of `media.role`, and libpulse reads `PULSE_PROP_<key>` verbatim at context creation (`proplist-util.c:123`), one env var at MPD launch gives each instance a permanently private entry:

```python
env["PULSE_PROP_module-stream-restore.id"] = f"bt-audio-manager:{self._address}"
```

Key is taken up to the first `=` and the value is the rest, with no unescaping — so the hyphens in the key and the colons in the MAC are both safe. MPD proves the mechanism works, since that's how it sets `media.role` itself.

## Why at launch rather than normalising the stream at runtime

The runtime approach in #285 works today, but writes to the sink-input volume:

- **It stops being safe if `flat-volumes` is ever enabled.** Under flat volumes PA raises the sink to match its loudest input, and on a bluez sink that propagates straight out as AVRCP Absolute Volume — the speaker's hardware level jumps to maximum on playback start, our `_on_pa_volume_change` handler sees it, syncs it back to MPD, and HA's slider follows. HAOS leaves `flat-volumes` commented out and PA v17.0's compiled default is `false` (`src/daemon/daemon-conf.c:71`), so it's off — but HAOS's vendored `daemon.conf` still carries the stale comment `; flat-volumes = yes` (upstream v17 ships `; flat-volumes = no`). Setting the id at launch cannot touch sink volume at all, so the failure mode doesn't exist.
- **No `sink_input` event subscription.** #285 wakes us for every stream created by every client on the shared PA server, each costing two round-trips on `self._pulse`, which has no lock and is shared with every other caller in `pulse.py`.
- **It doesn't override a deliberate setting.** A user who lowers the MPD stream keeps it, instead of having it silently reset at next playback start.

## Verification

Behaviour traced through PulseAudio v17.0 and MPD sources; **not yet tested on hardware**. Two things to confirm on a real system:

1. Our key doesn't collide with MPD's own `setenv` — different key, and `PULSE_PROP_` only sets when the property is absent, so it shouldn't.
2. The first-run entry saves at 100% and stays there.

The check: play to a speaker, then `pactl list sink-inputs` and confirm the MPD stream shows `module-stream-restore.id = "bt-audio-manager:<mac>"` and `Volume: front-left: 65536 / 100%`.

Supersedes #285