### PR TITLE
ci: add hardware-free unit test suite

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,73 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - dev
+      - main
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/FUNDING.yml"
+      - "repository.json"
+      - "LICENSE"
+  pull_request:
+    branches:
+      - dev
+      - main
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/FUNDING.yml"
+      - "repository.json"
+      - "LICENSE"
+
+jobs:
+  test:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          # Matches the python3 shipped in the HA base image (Alpine 3.20)
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: docker/requirements.txt
+
+      - name: Install libpulse
+        # pulsectl dlopen()s libpulse.so.0 at import time, so anything
+        # importing bt_audio_manager.audio (or manager) needs it present.
+        run: sudo apt-get update && sudo apt-get install -y libpulse0
+
+      - name: Install dependencies
+        run: pip install -r docker/requirements.txt
+
+      - name: Byte-compile all sources
+        run: python -m compileall -q src tests
+
+      - name: Check every module imports
+        # Tests skip themselves when libpulse is missing so contributors on
+        # macOS aren't blocked; this step makes sure that never silently
+        # hides a broken import in CI.
+        env:
+          PYTHONPATH: src
+        run: |
+          python -c "
+          import importlib, pkgutil
+          import bt_audio_manager
+          for m in pkgutil.walk_packages(bt_audio_manager.__path__, 'bt_audio_manager.'):
+              importlib.import_module(m.name)
+              print('ok', m.name)
+          "
+
+      - name: Run unit tests
+        env:
+          PYTHONPATH: src
+        # -t . so the tests package __init__ runs (it silences add-on logging)
+        run: python -m unittest discover -s tests -t . -v

--- a/docs/test-roadmap.md
+++ b/docs/test-roadmap.md
@@ -1,0 +1,143 @@
+# Test Roadmap
+
+Status: **Planned** — backlog of tests to add on top of the suite introduced in PR #290. Each item is independently actionable; work top-down.
+
+## Constraints
+
+CI has no Bluetooth adapter, no D-Bus, and no PulseAudio server. Everything here is exercisable with plain data. Anything needing a live `org.bluez` object, a real PA connection, or an actual speaker stays a manual hardware check.
+
+Run the suite with:
+
+```bash
+PYTHONPATH=src python -m unittest discover -s tests -t . -v
+```
+
+## The habit that matters most
+
+When a hardware-specific bug is diagnosed, capture the affected device's properties from its log into a test, and assert the **decision** that went wrong — not the hardware behaviour. `tests/test_discovery_filter.py` is built this way from the scan output attached to #286, so a regression reads as *"the Soundcore stopped being recognised"* rather than an abstract assertion failure.
+
+Every issue with a log attached is a potential test fixture. That is the cheapest source of high-value cases this project has.
+
+---
+
+## Tier 1 — guards bugs this repo has actually had
+
+### 1. `get_audio_devices()` end-to-end with a fake ObjectManager
+
+**Where:** new `tests/test_get_audio_devices.py`
+**Depends on:** #288 (assert the post-fix behaviour, so land it there or after)
+
+`tests/test_discovery_filter.py` covers the helpers, but not the filter itself — the code that broke in #286 and that #288 changes. It consumes a `GetManagedObjects()` dict and returns a device list, which is entirely fakeable.
+
+Build a fake bus exposing `introspect()` / `get_proxy_object()` returning a captured payload from a real scan, then assert exactly which devices are surfaced and which are skipped.
+
+Cases worth encoding, all present in the #286 log:
+
+- Soundcore 3 — vendor-only UUID + Audio/Video CoD → surfaced via CoD fallback
+- DS1190 — no UUIDs + audio CoD → surfaced via CoD fallback
+- Nebula projector — A2DP Source + AVRCP + Audio/Video CoD → **skipped** (the regression #287 would have introduced)
+- normal speaker — A2DP Sink → surfaced via UUID match
+- `cod_fallback=False` → CoD-only devices are **not** surfaced (the ghost-device guard)
+- `cod_matched` is set correctly on the returned dict (the UI badge depends on it)
+- `_logged_cache` dedupes repeat scans without suppressing accepted devices
+
+**Why it's first:** "which devices show up" is the single most common support issue in this repo.
+
+### 2. PulseAudio card profile name matching
+
+**Where:** new `tests/test_pulse_profiles.py`
+**Needs a small refactor first**
+
+HAOS's native HFP backend names the profile `handsfree_head_unit`; oFono names it `headset_head_unit`; hyphenated variants exist too. The matching lives inside `activate_bt_card_profile()` in `src/bt_audio_manager/audio/pulse.py`, tangled with live PA calls.
+
+Extract the decision — *given this list of profile names, pick the one for a2dp / hfp* — into a pure function, then test it against real profile lists captured from both backends, plus the no-match case.
+
+**Why:** string matching against names that vary by backend, with no test, is exactly how silent breakage happens after a HAOS bump.
+
+### 3. Config and settings validation
+
+**Where:** new `tests/test_config.py`
+
+`src/bt_audio_manager/config.py`: `AppConfig.load()`, `runtime_settings`, `save_settings`, `bt_adapter_is_mac`, `bt_adapter_is_legacy_hci`.
+
+Cover: defaults when the settings file is absent, malformed JSON, unknown keys, out-of-range values, MAC vs `hciN` adapter forms, and round-tripping a save/load.
+
+**Why:** users hand-edit these files; bad input should not take down startup.
+
+---
+
+## Tier 2 — cheap, catches renames
+
+### 4. Web API contract
+
+**Where:** new `tests/test_api.py`, using `aiohttp.test_utils.AioHTTPTestCase` with a fake manager
+
+`src/bt_audio_manager/web/api.py` is 775 lines with no coverage. Most of the value is as a **contract test against the frontend**: assert that device dicts carry the keys `web/static/app.js` reads — `cod_matched`, `signal_quality`, `has_transport`, `bearers`, `rssi`, `uuids`.
+
+Also worth: 404 on unknown device, 400 on malformed body, and that error responses carry a message the UI can display.
+
+**Why:** a backend rename that silently blanks part of the UI is a real failure mode and invisible to every other test.
+
+### 5. EventBus fan-out
+
+**Where:** new `tests/test_events.py`
+
+`src/bt_audio_manager/web/events.py` (40 lines): subscribe, emit reaches every subscriber, unsubscribe, no subscriber leak when a client disconnects mid-emit.
+
+**Why:** small, and the WebSocket path is load-bearing for the whole UI.
+
+### 6. Reconnect backoff schedule
+
+**Where:** new `tests/test_reconnect.py`
+**May need a small refactor**
+
+`src/bt_audio_manager/reconnect.py`. If the delay schedule is a pure function of attempt count, assert the curve and the ceiling directly. If it is interleaved with `asyncio.sleep`, extract the schedule first.
+
+### 7. `MPDManager._daemon_env()`
+
+**Where:** extend `tests/test_mpd_config.py`
+**Depends on:** #289
+
+Assert `PULSE_PROP_module-stream-restore.id` is set to the per-speaker value, and that the rest of the inherited environment survives (`PATH`, `PULSE_SERVER`).
+
+---
+
+## Tier 3 — non-obvious, higher leverage than they look
+
+### 8. AppArmor profile lint
+
+**Where:** new `tests/test_apparmor_profile.py`
+
+Parse `bluetooth_audio_manager/apparmor.txt` and cross-check it against what the code actually does:
+
+- every path the code `flock()`s carries the `k` permission (`/data/**`, `/tmp/**`, `/root/.config/pulse/**`)
+- paths the app reads/writes at runtime appear with matching permissions
+- the dev slug's profile stays in sync with the stable one
+
+**Why:** HAOS does **not** log AppArmor DENIED to dmesg or `ha host logs`, so these failures cannot be diagnosed from logs — they have to be caught by reading the profile. A test that does that reading automatically is worth well beyond its size. Pure text parsing, no hardware.
+
+### 9. Add-on metadata consistency
+
+**Where:** new `tests/test_addon_metadata.py`
+
+Compare `bluetooth_audio_manager/config.yaml` and `bluetooth_audio_manager_dev/config.yaml`: identical options schema, identical `map:` entries, differing only in slug, name, image, and version.
+
+**Why:** the Supervisor reads add-on metadata from `main`, and the dev build workflow syncs `config.yaml` and `apparmor.txt` from dev→main. Any *new* metadata file added to the dev slug must be added to that sync step too — a drift this test would surface. See #215.
+
+### 10. Frontend helpers
+
+**Where:** new `tests/js/`, run with `node --test`
+**Only if the JS surface is worth a second toolchain**
+
+`profileLabels()` and the device-card rendering helpers in `web/static/app.js` — mainly the UUID→label mapping.
+
+---
+
+## Explicitly out of scope
+
+Mocking these tests the mock, not the system:
+
+- live D-Bus wrappers — `bluez/device.py`, `bluez/media_player.py`, `bluez/agent.py`
+- keep-alive subprocess plumbing — `audio/keepalive.py`
+- real PulseAudio connections and sink state transitions
+- anything whose correctness depends on BlueZ or PA behaviour rather than on our decisions

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,36 @@
+# Tests
+
+Hardware-free unit tests for the pure logic in `src/bt_audio_manager/`.
+
+```bash
+pip install -r docker/requirements.txt
+PYTHONPATH=src python -m unittest discover -s tests -t . -v
+```
+
+CI runs the same command on every push to `dev`/`main` and every PR into
+them (`.github/workflows/test.yaml`).
+
+`pulsectl` `dlopen()`s `libpulse.so.0` when imported, so anything importing
+`bt_audio_manager.audio` or `bt_audio_manager.manager` needs it installed
+(`apt install libpulse0`). Those modules raise `unittest.SkipTest` when it
+is missing, so the suite still runs on a macOS or Windows dev machine — CI
+installs libpulse and additionally asserts every module imports, so a skip
+can't quietly hide a broken import.
+
+## Scope
+
+There is no Bluetooth adapter, no D-Bus and no PulseAudio server in CI, so
+these tests deliberately cover only logic that can be exercised with plain
+data:
+
+- decisions made *about* BlueZ/PulseAudio data (device filtering, CoD
+  decoding, sink-name parsing, RSSI classification)
+- text we generate for other programs to consume (`mpd.conf`)
+- state we own outright (the JSON device store, MPD port allocation)
+
+Anything that needs a live `org.bluez` object, a real PA connection, or an
+actual speaker is out of scope and is verified by hand on hardware. When a
+bug turns out to be hardware-specific, the useful thing to add here is a
+test for the *decision* that went wrong, using the properties captured from
+the affected device's logs — see `test_discovery_filter.py`, which is built
+from real scan output attached to issue #286.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,10 @@
+"""Test package.
+
+The add-on logs at INFO by default, and several tests deliberately drive
+error paths (corrupt store, exhausted MPD port pool). Silence logging so a
+failing assertion is the only thing in the output.
+"""
+
+import logging
+
+logging.disable(logging.CRITICAL)

--- a/tests/test_discovery_filter.py
+++ b/tests/test_discovery_filter.py
@@ -1,0 +1,140 @@
+"""Discovery filter: CoD decoding and rejection reasons.
+
+Device properties here are taken from real scan logs attached to issues,
+so a regression shows up as "the speaker from #286 stopped appearing"
+rather than as an abstract assertion failure.
+"""
+
+import unittest
+
+from bt_audio_manager.bluez.adapter import _classify_rejection
+from bt_audio_manager.bluez.constants import (
+    A2DP_SINK_UUID,
+    A2DP_SOURCE_UUID,
+    ASCS_UUID,
+    AVRCP_CONTROLLER_UUID,
+    AVRCP_TARGET_UUID,
+    HFP_UUID,
+    PACS_UUID,
+    cod_major_class,
+    cod_major_label,
+    cod_minor_class,
+    is_cod_audio_sink,
+)
+
+# Vendor UUIDs seen in the wild, none of which imply an audio profile.
+IAP2_ACCESSORY_UUID = "00000000-deca-fade-deca-deafdecacaff"  # Apple MFi
+HID_UUID = "00001812-0000-1000-8000-00805f9b34fb"
+BATTERY_UUID = "0000180f-0000-1000-8000-00805f9b34fb"
+
+
+class TestCodDecoding(unittest.TestCase):
+    """Class of Device bit unpacking (Bluetooth Assigned Numbers §2.8)."""
+
+    def test_soundcore_3_decodes_as_loudspeaker(self):
+        # Anker Soundcore 3, issue #286. BlueZ reported Class=2360340.
+        cod = 0x240414
+        self.assertEqual(cod, 2360340)
+        self.assertEqual(cod_major_class(cod), 0x04)
+        self.assertEqual(cod_major_label(cod), "Audio/Video")
+        self.assertEqual(cod_minor_class(cod), 5)  # Loudspeaker
+        self.assertTrue(is_cod_audio_sink(cod))
+
+    def test_rendering_and_audio_service_bits_are_set(self):
+        # A2DP v1.4.1 §5.5.1: a Sink sets the Rendering bit (18); bit 21
+        # is Audio. Both are set on the Soundcore's CoD.
+        cod = 0x240414
+        self.assertTrue(cod & (1 << 18), "Rendering service bit")
+        self.assertTrue(cod & (1 << 21), "Audio service bit")
+
+    def test_headset_minor_class_is_a_sink(self):
+        # DS1190, accepted via CoD fallback in the #286 log.
+        self.assertTrue(is_cod_audio_sink(0x240404))
+        self.assertEqual(cod_minor_class(0x240404), 1)  # Wearable Headset
+
+    def test_computer_major_class_is_not_a_sink(self):
+        # QUIETPC in the #286 log — has a CoD, but not an audio one.
+        self.assertEqual(cod_major_label(0x2E4104), "Computer")
+        self.assertFalse(is_cod_audio_sink(0x2E4104))
+
+    def test_microphone_and_camcorder_minors_are_not_sinks(self):
+        # Audio/Video major, but they capture rather than render.
+        for minor, what in ((4, "Microphone"), (13, "Camcorder")):
+            with self.subTest(what=what):
+                self.assertFalse(is_cod_audio_sink(0x200000 | (minor << 2) | 0x04))
+
+    def test_absent_cod_is_not_a_sink(self):
+        # BlueZ reports no Class property for most LE-only devices; the
+        # adapter substitutes 0.
+        self.assertFalse(is_cod_audio_sink(0))
+        self.assertEqual(cod_major_label(0), "Misc")
+
+
+class TestRejectionReasons(unittest.TestCase):
+    """The reason logged when a device is not surfaced."""
+
+    def test_source_only_device_is_named_as_such(self):
+        # Nebula projector (7C:E9:13:5E:B2:BB) from the #286 log: it
+        # advertises A2DP Source plus AVRCP and no sink.
+        uuids = {A2DP_SOURCE_UUID, AVRCP_TARGET_UUID, AVRCP_CONTROLLER_UUID}
+        self.assertIn("audio source only", _classify_rejection(uuids))
+
+    def test_a_source_that_is_also_a_sink_is_not_rejected_as_source(self):
+        uuids = {A2DP_SOURCE_UUID, A2DP_SINK_UUID}
+        self.assertNotIn("audio source only", _classify_rejection(uuids))
+
+    def test_le_audio_takes_precedence_over_other_reasons(self):
+        for uuid in (PACS_UUID, ASCS_UUID):
+            with self.subTest(uuid=uuid):
+                self.assertIn("LE Audio", _classify_rejection({uuid}))
+
+    def test_avrcp_only_remote(self):
+        reason = _classify_rejection({AVRCP_CONTROLLER_UUID, AVRCP_TARGET_UUID})
+        self.assertIn("AVRCP remote control only", reason)
+
+    def test_empty_uuids_reads_as_incomplete_sdp(self):
+        self.assertIn("no UUIDs advertised", _classify_rejection(set()))
+
+    def test_vendor_only_uuids_are_not_reported_as_empty(self):
+        # The Soundcore advertises exactly one UUID, so "no UUIDs
+        # advertised (incomplete SDP)" would be actively misleading.
+        reason = _classify_rejection({IAP2_ACCESSORY_UUID})
+        self.assertNotIn("no UUIDs advertised", reason)
+        self.assertIn("no audio sink profile", reason)
+
+    def test_unrelated_le_device(self):
+        # Litra Beam in the #286 log — HID plus battery service.
+        self.assertIn("no audio sink profile", _classify_rejection({HID_UUID, BATTERY_UUID}))
+
+
+class TestSinkUuidMembership(unittest.TestCase):
+    """SINK_UUIDS drives the primary match; AUDIO_UUIDS gates the fallback."""
+
+    def test_sink_uuids_hold_playback_profiles_only(self):
+        from bt_audio_manager.bluez.constants import SINK_UUIDS
+
+        self.assertIn(A2DP_SINK_UUID, SINK_UUIDS)
+        self.assertIn(HFP_UUID, SINK_UUIDS)
+        self.assertNotIn(A2DP_SOURCE_UUID, SINK_UUIDS)
+        self.assertNotIn(AVRCP_CONTROLLER_UUID, SINK_UUIDS)
+        self.assertNotIn(PACS_UUID, SINK_UUIDS)
+
+    def test_audio_uuids_is_a_superset_of_sink_uuids(self):
+        from bt_audio_manager.bluez.constants import AUDIO_UUIDS, SINK_UUIDS
+
+        self.assertTrue(SINK_UUIDS.issubset(AUDIO_UUIDS))
+        # It must also recognise the profiles we deliberately reject, or
+        # the CoD fallback cannot tell "no profile info" from "a profile
+        # we don't want".
+        for uuid in (A2DP_SOURCE_UUID, AVRCP_CONTROLLER_UUID, PACS_UUID):
+            with self.subTest(uuid=uuid):
+                self.assertIn(uuid, AUDIO_UUIDS)
+
+    def test_vendor_uuid_is_not_recognised_as_audio(self):
+        from bt_audio_manager.bluez.constants import AUDIO_UUIDS
+
+        self.assertNotIn(IAP2_ACCESSORY_UUID, AUDIO_UUIDS)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_manager_helpers.py
+++ b/tests/test_manager_helpers.py
@@ -1,0 +1,117 @@
+"""Pure helpers in manager.py: RSSI banding, sink-name and modalias parsing."""
+
+import unittest
+
+try:
+    from bt_audio_manager.manager import (
+        BluetoothAudioManager,
+        _dbus_val,
+        classify_signal,
+    )
+except OSError as exc:  # libpulse.so.0 is absent on non-Linux dev machines
+    raise unittest.SkipTest(f"libpulse not available: {exc}") from exc
+
+
+class FakeVariant:
+    """Stand-in for dbus_next.Variant, which only exposes .value here."""
+
+    def __init__(self, value):
+        self.value = value
+
+
+class TestClassifySignal(unittest.TestCase):
+    def test_bands(self):
+        cases = [
+            (-30, "excellent"),
+            (-49, "excellent"),
+            (-50, "good"),      # boundary: > -50 is excellent, -50 is not
+            (-64, "good"),
+            (-65, "fair"),
+            (-74, "fair"),
+            (-75, "weak"),
+            (-84, "weak"),
+            (-85, "very_weak"),
+            (-100, "very_weak"),
+        ]
+        for rssi, expected in cases:
+            with self.subTest(rssi=rssi):
+                self.assertEqual(classify_signal(rssi), expected)
+
+    def test_missing_rssi_is_unknown_not_a_band(self):
+        # BlueZ clears RSSI when discovery stops; None must not be
+        # rendered as "very_weak" or the UI shows a false warning.
+        self.assertIsNone(classify_signal(None))
+
+    def test_zero_is_treated_as_a_reading(self):
+        self.assertEqual(classify_signal(0), "excellent")
+
+
+class TestDbusVal(unittest.TestCase):
+    def test_unwraps_a_variant(self):
+        self.assertEqual(_dbus_val(FakeVariant("Speaker")), "Speaker")
+
+    def test_none_yields_the_default(self):
+        self.assertIsNone(_dbus_val(None))
+        self.assertEqual(_dbus_val(None, "fallback"), "fallback")
+
+    def test_plain_value_passes_through(self):
+        self.assertEqual(_dbus_val("already unwrapped"), "already unwrapped")
+
+    def test_falsy_variant_value_is_preserved(self):
+        # A device with RSSI 0 or Connected=False must not collapse to
+        # the default.
+        self.assertEqual(_dbus_val(FakeVariant(0), 99), 0)
+        self.assertIs(_dbus_val(FakeVariant(False), True), False)
+
+
+class TestAddrFromSinkName(unittest.TestCase):
+    def test_extracts_mac_from_a_bluez_sink(self):
+        self.assertEqual(
+            BluetoothAudioManager._addr_from_sink_name(
+                "bluez_sink.AA_BB_CC_DD_EE_FF.a2dp_sink"
+            ),
+            "AA:BB:CC:DD:EE:FF",
+        )
+
+    def test_handles_the_hfp_profile_suffix(self):
+        self.assertEqual(
+            BluetoothAudioManager._addr_from_sink_name(
+                "bluez_sink.AA_BB_CC_DD_EE_FF.handsfree_head_unit"
+            ),
+            "AA:BB:CC:DD:EE:FF",
+        )
+
+    def test_non_bluez_sink_yields_empty(self):
+        self.assertEqual(BluetoothAudioManager._addr_from_sink_name("nosuchsink"), "")
+
+    def test_alsa_sink_does_not_produce_a_bogus_address(self):
+        addr = BluetoothAudioManager._addr_from_sink_name(
+            "alsa_output.pci-0000_00_1f.3.analog-stereo"
+        )
+        self.assertNotIn(":", addr.replace("pci-0000_00_1f", ""))
+
+
+class TestModaliasToUsbId(unittest.TestCase):
+    def test_parses_a_usb_modalias(self):
+        self.assertEqual(
+            BluetoothAudioManager._modalias_to_usb_id("usb:v2357p0604d0001"),
+            "2357:0604",
+        )
+
+    def test_result_is_lowercased(self):
+        self.assertEqual(
+            BluetoothAudioManager._modalias_to_usb_id("usb:vABCDpEF01d0001"),
+            "abcd:ef01",
+        )
+
+    def test_non_usb_modalias_returns_none(self):
+        self.assertIsNone(BluetoothAudioManager._modalias_to_usb_id("pci:v00008086d00001234"))
+
+    def test_malformed_input_returns_none(self):
+        for value in ("", "usb:", "usb:vZZZZpYYYY", "not a modalias"):
+            with self.subTest(value=value):
+                self.assertIsNone(BluetoothAudioManager._modalias_to_usb_id(value))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_manager_helpers.py
+++ b/tests/test_manager_helpers.py
@@ -84,11 +84,18 @@ class TestAddrFromSinkName(unittest.TestCase):
     def test_non_bluez_sink_yields_empty(self):
         self.assertEqual(BluetoothAudioManager._addr_from_sink_name("nosuchsink"), "")
 
-    def test_alsa_sink_does_not_produce_a_bogus_address(self):
-        addr = BluetoothAudioManager._addr_from_sink_name(
-            "alsa_output.pci-0000_00_1f.3.analog-stereo"
+    def test_non_bluez_sink_yields_nonsense_and_relies_on_caller_gating(self):
+        # This is a positional split, not a parser: an alsa sink name
+        # produces a plausible-looking but meaningless "address". Callers
+        # gate on "bluez" appearing in the sink name (see the event
+        # monitor in audio/pulse.py) before calling, so the behaviour is
+        # characterised here rather than defended against.
+        self.assertEqual(
+            BluetoothAudioManager._addr_from_sink_name(
+                "alsa_output.pci-0000_00_1f.3.analog-stereo"
+            ),
+            "pci-0000:00:1f",
         )
-        self.assertNotIn(":", addr.replace("pci-0000_00_1f", ""))
 
 
 class TestModaliasToUsbId(unittest.TestCase):

--- a/tests/test_mpd_config.py
+++ b/tests/test_mpd_config.py
@@ -1,0 +1,110 @@
+"""MPD config generation.
+
+mpd.conf is text we hand to another program, so the interesting failures
+are quoting ones: a speaker whose name contains a double quote must not be
+able to terminate the string and inject a directive.
+"""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+try:
+    from bt_audio_manager.audio.mpd import MPDManager
+except OSError as exc:  # libpulse.so.0 is absent on non-Linux dev machines
+    raise unittest.SkipTest(f"libpulse not available: {exc}") from exc
+
+ADDR = "AA:BB:CC:DD:EE:FF"
+SINK = "bluez_sink.AA_BB_CC_DD_EE_FF.a2dp_sink"
+
+
+def build(speaker_name="Kitchen Speaker", *, port=6600, password=None, log_level="info"):
+    """Return (manager, generated_config_text) with paths in a temp dir."""
+    tmp = tempfile.TemporaryDirectory()
+    mpd = MPDManager(
+        address=ADDR,
+        port=port,
+        speaker_name=speaker_name,
+        password=password,
+        log_level=log_level,
+    )
+    mpd._tmp_dir = tmp.name
+    mpd._conf_path = str(Path(tmp.name) / "mpd.conf")
+    mpd._pid_file = str(Path(tmp.name) / "pid")
+    mpd._sink_name = SINK
+    mpd._generate_config()
+    return mpd, Path(mpd._conf_path).read_text(), tmp
+
+
+class TestConfigGeneration(unittest.TestCase):
+    def test_targets_the_requested_port_and_sink(self):
+        _, config, tmp = build(port=6603)
+        self.addCleanup(tmp.cleanup)
+        self.assertIn('port                "6603"', config)
+        self.assertIn(f'sink    "{SINK}"', config)
+
+    def test_uses_the_software_mixer(self):
+        # Issue #274: the pulse mixer only reports a volume while a
+        # sink-input exists, so HA hides the slider when MPD is idle.
+        _, config, tmp = build()
+        self.addCleanup(tmp.cleanup)
+        self.assertIn('mixer_type    "software"', config)
+
+    def test_password_line_present_only_when_set(self):
+        _, without, tmp1 = build(password=None)
+        self.addCleanup(tmp1.cleanup)
+        self.assertNotIn("password", without)
+
+        _, with_pw, tmp2 = build(password="s3cret")
+        self.addCleanup(tmp2.cleanup)
+        self.assertIn('password "s3cret@read,add,control,admin"', with_pw)
+
+    def test_log_level_follows_app_log_level(self):
+        _, verbose, tmp1 = build(log_level="debug")
+        self.addCleanup(tmp1.cleanup)
+        self.assertIn('log_level           "verbose"', verbose)
+
+        _, default, tmp2 = build(log_level="info")
+        self.addCleanup(tmp2.cleanup)
+        self.assertIn('log_level           "default"', default)
+
+    def test_no_state_or_db_file_is_configured(self):
+        # MPD 0.24 writes those with O_TMPFILE + linkat(AT_EMPTY_PATH),
+        # which needs CAP_DAC_READ_SEARCH — not available in HA add-on
+        # containers. Omitting them makes MPD skip saving entirely.
+        _, config, tmp = build()
+        self.addCleanup(tmp.cleanup)
+        self.assertNotIn("state_file", config)
+        self.assertNotIn("db_file", config)
+
+
+class TestSpeakerNameQuoting(unittest.TestCase):
+    def test_double_quote_in_name_is_escaped(self):
+        _, config, tmp = build('Bose "SoundLink"')
+        self.addCleanup(tmp.cleanup)
+        self.assertIn(r'name    "Bose \"SoundLink\""', config)
+
+    def test_backslash_in_name_is_escaped(self):
+        _, config, tmp = build(r"Back\slash")
+        self.addCleanup(tmp.cleanup)
+        self.assertIn(r'name    "Back\\slash"', config)
+
+    def test_quote_cannot_terminate_the_string_early(self):
+        # A name crafted to close the quoted value and append a directive
+        # must leave every quote escaped, so MPD reads the whole thing as
+        # one string rather than as a new setting.
+        _, config, tmp = build('Evil" state_file "/tmp/pwned')
+        self.addCleanup(tmp.cleanup)
+        self.assertIn(r'name    "Evil\" state_file \"/tmp/pwned"', config)
+        # No bare (unescaped) quote survives inside the value.
+        value = config.split('name    "', 1)[1].split('"\n', 1)[0]
+        self.assertNotIn('" ', value.replace(r"\"", ""))
+
+    def test_ordinary_unicode_name_is_left_alone(self):
+        _, config, tmp = build("Café Küche 🔊")
+        self.addCleanup(tmp.cleanup)
+        self.assertIn('name    "Café Küche 🔊"', config)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,0 +1,233 @@
+"""Persistence store: device records, settings defaults, MPD port pool."""
+
+import asyncio
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from bt_audio_manager.persistence.store import (
+    DEFAULT_DEVICE_SETTINGS,
+    MPD_PORT_MAX,
+    MPD_PORT_MIN,
+    PersistenceStore,
+)
+
+ADDR_A = "AA:BB:CC:DD:EE:01"
+ADDR_B = "AA:BB:CC:DD:EE:02"
+
+
+class StoreTestCase(unittest.IsolatedAsyncioTestCase):
+    """Base: a store backed by a real file in a temp dir."""
+
+    async def asyncSetUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.path = Path(self._tmp.name) / "paired_devices.json"
+        self.store = PersistenceStore(str(self.path))
+        await self.store.load()
+
+
+class TestDeviceRecords(StoreTestCase):
+    async def test_add_then_read_back_from_disk(self):
+        await self.store.add_device(ADDR_A, "Kitchen Speaker")
+
+        reloaded = PersistenceStore(str(self.path))
+        await reloaded.load()
+        self.assertEqual(len(reloaded.devices), 1)
+        self.assertEqual(reloaded.get_device(ADDR_A)["name"], "Kitchen Speaker")
+
+    async def test_adding_the_same_address_updates_rather_than_duplicates(self):
+        await self.store.add_device(ADDR_A, "Old Name")
+        await self.store.add_device(ADDR_A, "New Name", auto_connect=False)
+
+        self.assertEqual(len(self.store.devices), 1)
+        device = self.store.get_device(ADDR_A)
+        self.assertEqual(device["name"], "New Name")
+        self.assertFalse(device["auto_connect"])
+        # paired_at is set once, on first pairing.
+        self.assertIn("paired_at", device)
+
+    async def test_devices_property_returns_a_copy(self):
+        await self.store.add_device(ADDR_A, "Speaker")
+        self.store.devices.clear()
+        self.assertEqual(len(self.store.devices), 1)
+
+    async def test_auto_connect_excludes_only_devices_opted_out(self):
+        await self.store.add_device(ADDR_A, "A")
+        await self.store.add_device(ADDR_B, "B", auto_connect=False)
+        addrs = [d["address"] for d in self.store.auto_connect_devices]
+        self.assertEqual(addrs, [ADDR_A])
+
+    async def test_legacy_record_without_auto_connect_key_is_included(self):
+        self.path.write_text(json.dumps({"devices": [{"address": ADDR_A, "name": "Legacy"}]}))
+        store = PersistenceStore(str(self.path))
+        await store.load()
+        self.assertEqual([d["address"] for d in store.auto_connect_devices], [ADDR_A])
+
+    async def test_remove_and_clear(self):
+        await self.store.add_device(ADDR_A, "A")
+        await self.store.add_device(ADDR_B, "B")
+        await self.store.remove_device(ADDR_A)
+        self.assertEqual([d["address"] for d in self.store.devices], [ADDR_B])
+        await self.store.clear_all()
+        self.assertEqual(self.store.devices, [])
+
+    async def test_removing_an_unknown_address_is_a_no_op(self):
+        await self.store.add_device(ADDR_A, "A")
+        await self.store.remove_device("FF:FF:FF:FF:FF:FF")
+        self.assertEqual(len(self.store.devices), 1)
+
+
+class TestPersistenceMechanics(StoreTestCase):
+    async def test_save_is_atomic_and_leaves_no_temp_file(self):
+        await self.store.add_device(ADDR_A, "A")
+        leftovers = list(Path(self._tmp.name).glob("*.tmp"))
+        self.assertEqual(leftovers, [], f"temp file not cleaned up: {leftovers}")
+
+    async def test_corrupt_json_loads_as_empty_rather_than_raising(self):
+        self.path.write_text("{ this is not json")
+        store = PersistenceStore(str(self.path))
+        await store.load()
+        self.assertEqual(store.devices, [])
+
+    async def test_missing_file_loads_as_empty(self):
+        store = PersistenceStore(str(Path(self._tmp.name) / "absent.json"))
+        await store.load()
+        self.assertEqual(store.devices, [])
+
+    async def test_legacy_data_path_is_migrated_on_load(self):
+        # /data/paired_devices.json → /config/paired_devices.json. Patched
+        # to temp paths; the real constants point at container locations.
+        from bt_audio_manager.persistence import store as store_mod
+
+        legacy = Path(self._tmp.name) / "legacy.json"
+        legacy.write_text(json.dumps({"devices": [{"address": ADDR_A, "name": "Legacy"}]}))
+        target = Path(self._tmp.name) / "migrated.json"
+
+        original = store_mod.LEGACY_STORE_PATH
+        store_mod.LEGACY_STORE_PATH = str(legacy)
+        try:
+            migrated = PersistenceStore(str(target))
+            await migrated.load()
+        finally:
+            store_mod.LEGACY_STORE_PATH = original
+
+        self.assertEqual(migrated.get_device(ADDR_A)["name"], "Legacy")
+        self.assertTrue(target.exists(), "migrated file should be written to the new path")
+
+
+class TestDeviceSettings(StoreTestCase):
+    async def test_unknown_device_gets_plain_defaults(self):
+        self.assertEqual(self.store.get_device_settings("FF:FF:FF:FF:FF:FF"), DEFAULT_DEVICE_SETTINGS)
+
+    async def test_missing_keys_are_filled_with_defaults(self):
+        await self.store.add_device(ADDR_A, "A")
+        settings = self.store.get_device_settings(ADDR_A)
+        self.assertEqual(set(settings), set(DEFAULT_DEVICE_SETTINGS))
+        self.assertEqual(settings["audio_profile"], "a2dp")
+        self.assertIs(settings["mpd_enabled"], False)
+
+    async def test_update_persists_and_ignores_unknown_keys(self):
+        await self.store.add_device(ADDR_A, "A")
+        await self.store.update_device_settings(
+            ADDR_A, {"idle_mode": "power_save", "not_a_real_setting": 1}
+        )
+
+        reloaded = PersistenceStore(str(self.path))
+        await reloaded.load()
+        self.assertEqual(reloaded.get_device_settings(ADDR_A)["idle_mode"], "power_save")
+        self.assertNotIn("not_a_real_setting", reloaded.get_device(ADDR_A))
+
+    async def test_update_on_unknown_device_returns_none(self):
+        self.assertIsNone(await self.store.update_device_settings(ADDR_A, {"idle_mode": "power_save"}))
+
+    async def test_legacy_keep_alive_flag_migrates_to_idle_mode(self):
+        await self.store.add_device(ADDR_A, "A")
+        self.store.get_device(ADDR_A)["keep_alive_enabled"] = True
+        self.assertEqual(self.store.get_device_settings(ADDR_A)["idle_mode"], "keep_alive")
+
+        self.store.get_device(ADDR_A)["keep_alive_enabled"] = False
+        self.assertEqual(self.store.get_device_settings(ADDR_A)["idle_mode"], "default")
+
+    async def test_explicit_idle_mode_wins_over_legacy_flag(self):
+        await self.store.add_device(ADDR_A, "A")
+        device = self.store.get_device(ADDR_A)
+        device["keep_alive_enabled"] = True
+        device["idle_mode"] = "auto_disconnect"
+        self.assertEqual(self.store.get_device_settings(ADDR_A)["idle_mode"], "auto_disconnect")
+
+
+class TestMpdPortAllocation(StoreTestCase):
+    async def test_allocates_lowest_free_port(self):
+        await self.store.add_device(ADDR_A, "A")
+        await self.store.add_device(ADDR_B, "B")
+        self.assertEqual(await self.store.allocate_mpd_port(ADDR_A), MPD_PORT_MIN)
+        self.assertEqual(await self.store.allocate_mpd_port(ADDR_B), MPD_PORT_MIN + 1)
+
+    async def test_allocation_is_idempotent(self):
+        await self.store.add_device(ADDR_A, "A")
+        first = await self.store.allocate_mpd_port(ADDR_A)
+        self.assertEqual(await self.store.allocate_mpd_port(ADDR_A), first)
+
+    async def test_released_port_is_reused_by_the_next_device(self):
+        await self.store.add_device(ADDR_A, "A")
+        await self.store.add_device(ADDR_B, "B")
+        await self.store.allocate_mpd_port(ADDR_A)
+        await self.store.allocate_mpd_port(ADDR_B)
+        await self.store.release_mpd_port(ADDR_A)
+        self.assertEqual(await self.store.allocate_mpd_port(ADDR_A), MPD_PORT_MIN)
+
+    async def test_pool_exhaustion_returns_none(self):
+        count = MPD_PORT_MAX - MPD_PORT_MIN + 1
+        for i in range(count):
+            addr = f"AA:BB:CC:DD:EE:{i:02X}"
+            await self.store.add_device(addr, f"Speaker {i}")
+            self.assertIsNotNone(await self.store.allocate_mpd_port(addr))
+
+        overflow = "AA:BB:CC:DD:FF:FF"
+        await self.store.add_device(overflow, "One too many")
+        self.assertIsNone(await self.store.allocate_mpd_port(overflow))
+
+    async def test_allocation_for_unknown_device_returns_none(self):
+        self.assertIsNone(await self.store.allocate_mpd_port("FF:FF:FF:FF:FF:FF"))
+
+    async def test_manual_port_rejects_out_of_range(self):
+        await self.store.add_device(ADDR_A, "A")
+        self.assertFalse(await self.store.set_mpd_port(ADDR_A, MPD_PORT_MIN - 1))
+        self.assertFalse(await self.store.set_mpd_port(ADDR_A, MPD_PORT_MAX + 1))
+        self.assertTrue(await self.store.set_mpd_port(ADDR_A, MPD_PORT_MAX))
+
+    async def test_manual_port_rejects_collision_but_allows_self(self):
+        await self.store.add_device(ADDR_A, "A")
+        await self.store.add_device(ADDR_B, "B")
+        self.assertTrue(await self.store.set_mpd_port(ADDR_A, 6605))
+        self.assertFalse(await self.store.set_mpd_port(ADDR_B, 6605))
+        # Re-asserting a device's own port is not a collision.
+        self.assertTrue(await self.store.set_mpd_port(ADDR_A, 6605))
+
+    async def test_manual_port_survives_a_reload(self):
+        await self.store.add_device(ADDR_A, "A")
+        await self.store.set_mpd_port(ADDR_A, 6607)
+
+        reloaded = PersistenceStore(str(self.path))
+        await reloaded.load()
+        self.assertEqual(reloaded.get_device_settings(ADDR_A)["mpd_port"], 6607)
+
+    async def test_allocation_skips_a_manually_assigned_port(self):
+        await self.store.add_device(ADDR_A, "A")
+        await self.store.add_device(ADDR_B, "B")
+        await self.store.set_mpd_port(ADDR_A, MPD_PORT_MIN)
+        self.assertEqual(await self.store.allocate_mpd_port(ADDR_B), MPD_PORT_MIN + 1)
+
+    async def test_concurrent_allocations_do_not_collide(self):
+        addrs = [f"AA:BB:CC:DD:EE:{i:02X}" for i in range(5)]
+        for addr in addrs:
+            await self.store.add_device(addr, addr)
+
+        ports = await asyncio.gather(*(self.store.allocate_mpd_port(a) for a in addrs))
+        self.assertEqual(len(set(ports)), len(addrs), f"duplicate ports handed out: {ports}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Delivers what I said I'd add on #285: a test job, plus the first tests to run in it.

## Why now

The repo has no tests and no job to run them. Worse, `build.yaml` only triggers `pull_request` on `main`, so **PRs into `dev` currently get no checks at all** — including #288 and #289.

## What's here

`.github/workflows/test.yaml` — pushes to `dev`/`main`, PRs into either. Python 3.12 to match the `python3` in the Alpine 3.20 HA base image.

53 tests over the logic that can be exercised without a Bluetooth adapter, D-Bus, or a PulseAudio server:

| file | covers |
|---|---|
| `test_discovery_filter.py` | CoD decoding, `is_cod_audio_sink`, rejection reasons, `SINK_UUIDS` / `AUDIO_UUIDS` membership |
| `test_store.py` | device records, settings defaults, `keep_alive_enabled` → `idle_mode` migration, `/data` → `/config` migration, atomic save, MPD port pool |
| `test_mpd_config.py` | `mpd.conf` generation: port/sink/mixer/password/log level, speaker-name quoting |
| `test_manager_helpers.py` | RSSI banding boundaries, D-Bus variant unwrapping, sink-name and modalias parsing |

Device properties in `test_discovery_filter.py` are taken from the real scan log attached to #286, so a regression reads as *"the Soundcore stopped being recognised"* rather than an abstract assertion failure. That's the pattern I'd like to keep: when a bug turns out to be hardware-specific, add a test for the **decision** that went wrong, using properties captured from the affected device's logs.

## libpulse

`pulsectl` `dlopen()`s `libpulse.so.0` at import time, so anything importing `bt_audio_manager.audio` or `.manager` needs it. CI installs `libpulse0`; those two test modules raise `unittest.SkipTest` when it's absent so the suite still runs on a macOS dev machine. A separate CI step imports every module in the package, so a skip can never quietly hide a broken import.

## Notes

- Deliberately **not** included: tests for the behaviour changed in #288 and #289 — those belong on their own branches, and asserting the new behaviour here would fail against current `dev`. Once this lands I'll merge `dev` into both and add them.
- `build.yaml` still doesn't run on PRs into `dev`. I've left that alone: adding `dev` there would kick off a 4-arch QEMU build on every PR. Happy to add it if you'd rather have the build checked too.