### PR TITLE
fix(store,mpd): keep per-device settings and restart a dead MPD daemon

### DIFF
--- a/src/bt_audio_manager/audio/mpd.py
+++ b/src/bt_audio_manager/audio/mpd.py
@@ -95,7 +95,19 @@ class MPDManager:
 
     @property
     def is_running(self) -> bool:
-        return self._running and self._process is not None
+        """Whether the daemon is up *right now*.
+
+        The ``returncode`` check matters: MPD can exit on its own (its PA
+        sink disappearing during a Bluetooth drop is the common case).  A
+        holder that only asked "do I have an instance?" would then treat a
+        dead daemon as live and never restart it, leaving the media_player
+        entity permanently unavailable with nothing in the log.
+        """
+        return (
+            self._running
+            and self._process is not None
+            and self._process.returncode is None
+        )
 
     @property
     def port(self) -> int:

--- a/src/bt_audio_manager/manager.py
+++ b/src/bt_audio_manager/manager.py
@@ -2972,8 +2972,17 @@ class BluetoothAudioManager:
         settings = self.store.get_device_settings(address)
         if not settings.get("mpd_enabled", False):
             return
-        if address in self._mpd_instances:
-            return  # already running
+        existing = self._mpd_instances.get(address)
+        if existing is not None:
+            if existing.is_running:
+                return  # already running
+            # Daemon exited on its own (e.g. its PA sink vanished mid-drop).
+            # Drop the corpse so the restart below can take over — otherwise
+            # every later connect sees "already running" and MPD stays dead.
+            logger.warning(
+                "MPD for %s is no longer running — restarting it", address
+            )
+            await self._stop_mpd(address)
         if not self.pulse:
             return
 
@@ -3055,7 +3064,9 @@ class BluetoothAudioManager:
     async def _stop_mpd(self, address: str) -> None:
         """Stop the MPD instance for a specific device (keeps port assigned)."""
         mpd = self._mpd_instances.pop(address, None)
-        if mpd and mpd.is_running:
+        if mpd:
+            # Unconditional: a daemon that already exited still leaves a
+            # connected client and a stderr reader task behind.
             await mpd.stop()
 
     async def update_device_settings(self, address: str, settings: dict) -> dict | None:

--- a/src/bt_audio_manager/persistence/store.py
+++ b/src/bt_audio_manager/persistence/store.py
@@ -34,6 +34,18 @@ MPD_PORT_MIN = 6600
 MPD_PORT_MAX = 6609
 
 
+def normalize_address(address: str) -> str:
+    """Canonical form for a Bluetooth address: upper-case hex.
+
+    BlueZ always reports upper case, but callers do not: an HA template or
+    a hand-written REST call happily sends ``aa:bb:...``.  Without a single
+    canonical form those lookups miss an existing record, and the settings
+    endpoint then creates a *second* record from defaults — which reads to
+    the user as their MPD config silently resetting itself.
+    """
+    return address.upper() if isinstance(address, str) else address
+
+
 class PersistenceStore:
     """Manages persistent storage of paired Bluetooth audio devices."""
 
@@ -57,7 +69,7 @@ class PersistenceStore:
 
         try:
             data = json.loads(self._path.read_text())
-            self._devices = data.get("devices", [])
+            self._devices = self._canonicalise(data.get("devices", []))
             logger.info("Loaded %d paired device(s) from store", len(self._devices))
             for d in self._devices:
                 non_defaults = {
@@ -71,6 +83,35 @@ class PersistenceStore:
             logger.error("Failed to parse paired devices store: %s", e)
             self._devices = []
 
+    @staticmethod
+    def _canonicalise(devices: list[dict]) -> list[dict]:
+        """Upper-case stored addresses and drop case-duplicate records.
+
+        Heals stores already polluted by a mixed-case write.  The first
+        record for an address wins: duplicates are appended, so the first
+        is the original one carrying the user's real settings.
+        """
+        seen: dict[str, dict] = {}
+        result: list[dict] = []
+        for d in devices:
+            address = d.get("address")
+            if not isinstance(address, str):
+                logger.warning("Skipping store record with no usable address: %s", d)
+                continue
+            d["address"] = normalize_address(address)
+            kept = seen.get(d["address"])
+            if kept is not None:
+                logger.warning(
+                    "Discarding duplicate record for %s (address case mismatch); "
+                    "keeping the first, which has settings: %s",
+                    d["address"],
+                    {k: kept.get(k) for k in DEFAULT_DEVICE_SETTINGS if k in kept},
+                )
+                continue
+            seen[d["address"]] = d
+            result.append(d)
+        return result
+
     async def save(self) -> None:
         """Write current device list to disk (atomic via temp + rename)."""
         data = {"devices": self._devices}
@@ -83,6 +124,7 @@ class PersistenceStore:
         self, address: str, name: str, auto_connect: bool = True
     ) -> None:
         """Add or update a paired device."""
+        address = normalize_address(address)
         existing = self._find_device(address)
         if existing is not None:
             existing["name"] = name
@@ -101,6 +143,7 @@ class PersistenceStore:
 
     async def remove_device(self, address: str) -> None:
         """Remove a device from the store."""
+        address = normalize_address(address)
         self._devices = [d for d in self._devices if d["address"] != address]
         await self.save()
         logger.info("Removed device %s from store", address)
@@ -117,6 +160,7 @@ class PersistenceStore:
         return self._find_device(address)
 
     def _find_device(self, address: str) -> dict | None:
+        address = normalize_address(address)
         for d in self._devices:
             if d["address"] == address:
                 return d
@@ -185,6 +229,7 @@ class PersistenceStore:
         """
         if port < MPD_PORT_MIN or port > MPD_PORT_MAX:
             return False
+        address = normalize_address(address)
         device = self._find_device(address)
         if device is None:
             return False

--- a/src/bt_audio_manager/web/api.py
+++ b/src/bt_audio_manager/web/api.py
@@ -11,6 +11,8 @@ from aiohttp import web
 from aiohttp.web import WebSocketResponse
 from dbus_next.errors import DBusError
 
+from ..persistence.store import normalize_address
+
 if TYPE_CHECKING:
     from ..manager import BluetoothAudioManager
     from .log_handler import WebSocketLogHandler
@@ -82,6 +84,9 @@ def _get_validated_address(body: dict) -> tuple[str | None, web.Response | None]
     """Extract and validate a Bluetooth MAC address from a request body.
 
     Returns (address, None) on success or (None, error_response) on failure.
+    The address is normalised to upper case — BlueZ object paths, the
+    manager's per-device dicts and the persistence store are all keyed that
+    way, so a lower-case address from a caller must not reach them.
     """
     address = body.get("address")
     if not address:
@@ -91,7 +96,7 @@ def _get_validated_address(body: dict) -> tuple[str | None, web.Response | None]
             {"error": "Invalid Bluetooth address format (expected XX:XX:XX:XX:XX:XX)"},
             status=400,
         )
-    return address, None
+    return normalize_address(address), None
 
 
 async def _ws_sender(
@@ -341,6 +346,7 @@ def create_api_routes(
                 {"error": "Invalid Bluetooth address format (expected XX:XX:XX:XX:XX:XX)"},
                 status=400,
             )
+        address = normalize_address(address)
         try:
             # Auto-store paired devices not yet in the persistence store
             # (can happen when BlueZ paired a device before the add-on tracked it,

--- a/src/bt_audio_manager/web/static/openapi.yaml
+++ b/src/bt_audio_manager/web/static/openapi.yaml
@@ -429,6 +429,10 @@ paths:
         - name: address
           in: path
           required: true
+          description: >-
+            Case-insensitive; normalised to upper case before lookup, so a
+            lower-case address updates the existing device rather than
+            creating a second record.
           schema:
             type: string
             pattern: "^[0-9A-Fa-f]{2}(:[0-9A-Fa-f]{2}){5}$"
@@ -940,7 +944,10 @@ components:
         address:
           type: string
           pattern: "^[0-9A-Fa-f]{2}(:[0-9A-Fa-f]{2}){5}$"
-          description: Bluetooth MAC address, colon-separated.
+          description: >-
+            Bluetooth MAC address, colon-separated. Case-insensitive: the
+            address is normalised to upper case, which is the form BlueZ
+            uses and the form returned by every response.
           example: "AA:BB:CC:DD:EE:FF"
 
     Device:

--- a/tests/test_mpd_lifecycle.py
+++ b/tests/test_mpd_lifecycle.py
@@ -1,0 +1,107 @@
+"""MPD daemon liveness and the restart decision built on it.
+
+MPD can exit on its own — the common trigger is its PulseAudio sink going
+away while the speaker is dropping in and out.  If the add-on keeps
+treating that dead daemon as running, the HA media_player entity stays
+unavailable forever and nothing says why (issue #299).
+"""
+
+import unittest
+
+try:
+    from bt_audio_manager.audio.mpd import MPDManager
+    from bt_audio_manager.manager import BluetoothAudioManager
+except OSError as exc:  # libpulse.so.0 is absent on non-Linux dev machines
+    raise unittest.SkipTest(f"libpulse not available: {exc}") from exc
+
+ADDR = "AA:BB:CC:DD:EE:FF"
+
+
+class FakeProcess:
+    """Just the bit of asyncio.subprocess.Process that liveness reads."""
+
+    def __init__(self, returncode=None):
+        self.returncode = returncode
+
+
+class TestIsRunning(unittest.TestCase):
+    def build(self):
+        return MPDManager(address=ADDR, port=6600, speaker_name="Speaker")
+
+    def test_a_started_daemon_is_running(self):
+        mpd = self.build()
+        mpd._running = True
+        mpd._process = FakeProcess()
+        self.assertTrue(mpd.is_running)
+
+    def test_a_daemon_that_exited_is_not_running(self):
+        mpd = self.build()
+        mpd._running = True
+        mpd._process = FakeProcess(returncode=1)
+        self.assertFalse(mpd.is_running)
+
+    def test_a_daemon_that_exited_cleanly_is_not_running(self):
+        # returncode 0 is still gone — only None means "still alive".
+        mpd = self.build()
+        mpd._running = True
+        mpd._process = FakeProcess(returncode=0)
+        self.assertFalse(mpd.is_running)
+
+    def test_never_started_is_not_running(self):
+        self.assertFalse(self.build().is_running)
+
+
+class FakeStore:
+    def __init__(self, mpd_enabled=True):
+        self._settings = {"mpd_enabled": mpd_enabled}
+
+    def get_device_settings(self, address):
+        return dict(self._settings)
+
+
+class FakeMpd:
+    def __init__(self, running):
+        self.is_running = running
+        self.stopped = False
+
+    async def stop(self):
+        self.stopped = True
+
+
+class TestRestartDecision(unittest.IsolatedAsyncioTestCase):
+    """_start_mpd_if_enabled's handling of an instance it already holds.
+
+    ``pulse`` is None so the method returns right after that decision —
+    starting a real daemon needs a PulseAudio server.
+    """
+
+    def build(self, instance, *, mpd_enabled=True):
+        manager = BluetoothAudioManager.__new__(BluetoothAudioManager)
+        manager.store = FakeStore(mpd_enabled)
+        manager.pulse = None
+        manager._mpd_instances = {ADDR: instance}
+        return manager
+
+    async def test_a_live_instance_is_left_alone(self):
+        live = FakeMpd(running=True)
+        manager = self.build(live)
+        await manager._start_mpd_if_enabled(ADDR)
+        self.assertFalse(live.stopped)
+        self.assertIs(manager._mpd_instances.get(ADDR), live)
+
+    async def test_a_dead_instance_is_reaped_so_a_restart_can_follow(self):
+        dead = FakeMpd(running=False)
+        manager = self.build(dead)
+        await manager._start_mpd_if_enabled(ADDR)
+        self.assertTrue(dead.stopped, "dead daemon's client/reader task not cleaned up")
+        self.assertNotIn(ADDR, manager._mpd_instances)
+
+    async def test_disabled_device_is_untouched(self):
+        dead = FakeMpd(running=False)
+        manager = self.build(dead, mpd_enabled=False)
+        await manager._start_mpd_if_enabled(ADDR)
+        self.assertIs(manager._mpd_instances.get(ADDR), dead)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -79,6 +79,80 @@ class TestDeviceRecords(StoreTestCase):
         self.assertEqual(len(self.store.devices), 1)
 
 
+class TestAddressNormalisation(StoreTestCase):
+    """BlueZ reports upper case; REST callers and HA templates often don't.
+
+    Without one canonical form a lower-case lookup misses the record and
+    the settings endpoint creates a second one from defaults, which reads
+    to the user as their MPD config resetting itself (issue #299).
+    """
+
+    async def test_address_is_stored_upper_case(self):
+        await self.store.add_device(ADDR_A.lower(), "A")
+        self.assertEqual(self.store.devices[0]["address"], ADDR_A)
+
+    async def test_lookups_ignore_case(self):
+        await self.store.add_device(ADDR_A, "A")
+        self.assertIsNotNone(self.store.get_device(ADDR_A.lower()))
+        self.assertEqual(self.store.get_device_settings(ADDR_A.lower())["audio_profile"], "a2dp")
+
+    async def test_a_lower_case_write_updates_rather_than_duplicating(self):
+        await self.store.add_device(ADDR_A, "A")
+        await self.store.update_device_settings(ADDR_A.lower(), {"mpd_enabled": True})
+        await self.store.set_mpd_port(ADDR_A.lower(), 6604)
+
+        self.assertEqual(len(self.store.devices), 1)
+        settings = self.store.get_device_settings(ADDR_A)
+        self.assertIs(settings["mpd_enabled"], True)
+        self.assertEqual(settings["mpd_port"], 6604)
+
+    async def test_lower_case_add_does_not_duplicate_an_existing_record(self):
+        await self.store.add_device(ADDR_A, "A")
+        await self.store.update_device_settings(ADDR_A, {"mpd_enabled": True})
+        await self.store.add_device(ADDR_A.lower(), "A")
+
+        self.assertEqual(len(self.store.devices), 1)
+        self.assertIs(self.store.get_device_settings(ADDR_A)["mpd_enabled"], True)
+
+    async def test_remove_ignores_case(self):
+        await self.store.add_device(ADDR_A, "A")
+        await self.store.remove_device(ADDR_A.lower())
+        self.assertEqual(self.store.devices, [])
+
+    async def test_port_pool_sees_a_lower_case_record_as_taken(self):
+        self.path.write_text(json.dumps({"devices": [
+            {"address": ADDR_A.lower(), "name": "A", "mpd_port": MPD_PORT_MIN},
+            {"address": ADDR_B, "name": "B"},
+        ]}))
+        store = PersistenceStore(str(self.path))
+        await store.load()
+        self.assertEqual(await store.allocate_mpd_port(ADDR_B), MPD_PORT_MIN + 1)
+
+    async def test_load_heals_a_store_already_split_across_cases(self):
+        # What a polluted store looks like: the real record, then the
+        # default one a lower-case settings write appended after it.
+        self.path.write_text(json.dumps({"devices": [
+            {"address": ADDR_A, "name": "A", "mpd_enabled": True, "mpd_port": 6602},
+            {"address": ADDR_A.lower(), "name": "A", "mpd_enabled": False, "mpd_port": None},
+        ]}))
+        store = PersistenceStore(str(self.path))
+        await store.load()
+
+        self.assertEqual(len(store.devices), 1)
+        settings = store.get_device_settings(ADDR_A)
+        self.assertIs(settings["mpd_enabled"], True)
+        self.assertEqual(settings["mpd_port"], 6602)
+
+    async def test_healed_store_is_persisted_on_the_next_write(self):
+        self.path.write_text(json.dumps({"devices": [{"address": ADDR_A.lower(), "name": "A"}]}))
+        store = PersistenceStore(str(self.path))
+        await store.load()
+        await store.update_device_settings(ADDR_A, {"idle_mode": "power_save"})
+
+        written = json.loads(self.path.read_text())["devices"]
+        self.assertEqual([d["address"] for d in written], [ADDR_A])
+
+
 class TestPersistenceMechanics(StoreTestCase):
     async def test_save_is_atomic_and_leaves_no_temp_file(self):
         await self.store.add_device(ADDR_A, "A")


### PR DESCRIPTION
Two defects found while investigating #299 (*"MPD gets silently disabled per-device after Bluetooth reconnect/repair cycle"*). Neither is the reconnect service — it never touches the persistence store, so it cannot be the reported cause — but both produce the symptoms described in that issue.

## 1. Bluetooth addresses were compared case-sensitively

`_MAC_RE` accepts either case and nothing normalised, while `PersistenceStore._find_device` compared exact strings and BlueZ always reports upper case. So `PUT /api/devices/aa:bb:cc:dd:ee:ff/settings` — the form an HA template or a hand-written REST call produces — missed the existing record, and the endpoint's auto-store branch appended a **second** record built from `DEFAULT_DEVICE_SETTINGS`. That shadow record is exactly `mpd_enabled: false, mpd_port: null`, while the user's real settings sit in the record behind it.

- `normalize_address()` in `persistence/store.py`; applied on every store lookup and write.
- Applied at the API boundary too (`_get_validated_address` and the settings route), so a lower-case address never reaches BlueZ object paths or the manager's per-device dicts either.
- `load()` heals a store already split across cases: addresses are upper-cased, and a duplicate is dropped in favour of the first record — duplicates are appended, so the first is the original one carrying the real settings. The discarded record and its settings are logged at WARNING.

## 2. A dead MPD daemon was treated as running forever

`MPDManager.is_running` was `self._running and self._process is not None` — it never checked `returncode`. MPD can exit on its own, and its PulseAudio sink vanishing during a Bluetooth drop is the common way. `_start_mpd_if_enabled` then returned early on `if address in self._mpd_instances` for every subsequent connect, so the daemon stayed dead with nothing in the log and the HA `media_player` entity never came back.

- `is_running` now requires `returncode is None`.
- `_start_mpd_if_enabled` reaps a dead instance and restarts it, logging a warning that names the device.
- `_stop_mpd` stops unconditionally: a daemon that already exited still leaves a connected client and a stderr reader task behind.

## Tests

`tests/test_mpd_lifecycle.py` (new) covers daemon liveness and the reap-and-restart decision; `tests/test_store.py` gains `TestAddressNormalisation`, including the split-store healing case. Full suite green.

`openapi.yaml` documents that addresses are case-insensitive and normalised to upper case.

Fixes are candidates for #299 — the reporter still needs to confirm which mechanism they hit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)