### PR TITLE
chore(release): prepare 2.1.0

### DIFF
--- a/bluetooth_audio_manager/config.yaml
+++ b/bluetooth_audio_manager/config.yaml
@@ -1,5 +1,5 @@
 name: "Bluetooth Audio Manager"
-version: "2.0.1"
+version: "2.1.0"
 slug: bluetooth_audio_manager
 description: "Manage Bluetooth audio device connections (A2DP) with persistent pairing, auto-reconnect, and AppArmor security."
 url: "https://github.com/scyto/ha-bluetooth-audio-manager"

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,4 +1,4 @@
 dbus-next==0.2.3
 pulsectl-asyncio==1.2.0
-aiohttp==3.14.1
+aiohttp==3.14.3
 python-mpd2==3.1.1

--- a/docs/api.md
+++ b/docs/api.md
@@ -295,33 +295,13 @@ actions:
       enabled: false
 ```
 
-This takes effect immediately — no restart needed.
+This takes effect immediately — no restart needed. It also stops any reconnect attempt already
+under way, rather than waiting for the current backoff loop to give up.
 
-### Known exception: add-on restarts
-
-⚠️ **Auto Reconnect off does not currently survive a restart.** When the add-on starts — after an
-update, a Home Assistant restart, or a host reboot — it reconnects every stored device regardless
-of the Auto Reconnect setting. The setting is honoured while the add-on is running (a device that
-drops will not be reconnected), but not during startup.
-
-If you are relying on manual control to keep a speaker free for a phone, a restart will still
-seize it. Until this is fixed, either disconnect explicitly after a restart:
-
-```yaml
-automation:
-  - alias: "Release speaker after add-on restart"
-    triggers:
-      - trigger: homeassistant
-        event: start
-    actions:
-      - delay: "00:01:00"    # let the add-on finish its startup reconnect
-      - action: rest_command.bt_audio_disconnect
-        data:
-          address: "AA:BB:CC:DD:EE:FF"
-```
-
-…or remove the device from the add-on's store entirely (`POST /api/forget`) and pair it on demand,
-though that is heavier-handed.
+The setting persists across restarts. With Auto Reconnect off, the add-on does not reconnect
+stored devices when it starts — after an update, a Home Assistant restart, or a host reboot — so a
+speaker you deliberately left free for a phone stays free. Devices that are already connected are
+untouched: the add-on only stops *initiating* connections, it never tears one down.
 
 ---
 

--- a/src/bt_audio_manager/web/static/openapi.yaml
+++ b/src/bt_audio_manager/web/static/openapi.yaml
@@ -1100,7 +1100,10 @@ components:
           type: boolean
           description: >
             Automatically reconnect stored devices. Turn off to hand control
-            to Home Assistant automations calling `/api/connect`.
+            to Home Assistant automations calling `/api/connect`. Setting this
+            to `false` cancels reconnect attempts already in flight, and the
+            add-on will not reconnect stored devices on its next startup.
+            Devices that are already connected are left alone either way.
         reconnect_interval_seconds:
           type: integer
           minimum: 5


### PR DESCRIPTION
Release prep for 2.1.0, to be merged into `dev` before the `dev` → `main` promotion.

## Changes

- **`bluetooth_audio_manager/config.yaml` → 2.1.0.** The stable build workflow reads the GHCR image tag from this field, so it must move before the promotion merge or the Supervisor pulls a nonexistent tag.
- **aiohttp 3.14.1 → 3.14.3.** Supersedes dependabot #300, which was opened against `main` while `dev` already carried 3.14.1 — merging it there would have collided with this release merge on the same line.
- **`docs/api.md`:** removed the "Known exception: add-on restarts" section. #298 made `auto_reconnect: false` skip startup reconnection, so the caveat and its delay-then-disconnect automation are now actively wrong. Replaced with a short note on the real semantics.
- **`openapi.yaml`:** the `auto_reconnect` field description now covers the two behaviours #298 added — cancelling in-flight attempts, and suppressing startup reconnection.

## Verification

Full suite locally: **87 passed, 2 skipped** (the 2 skips are the libpulse-dependent cases that self-skip off-Linux; they run in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)