### PR TITLE
docs: correct stale claims after v2.1.0 and the XSS fix

### DIFF
--- a/bluetooth_audio_manager/DOCS.md
+++ b/bluetooth_audio_manager/DOCS.md
@@ -43,7 +43,7 @@ Bluetooth integration (used for BLE sensors, beacons, etc.):
 
 The header bar contains:
 
-- **Build info pill** — shows the version string (e.g. `1.5.0` for stable
+- **Build info pill** — shows the version string (e.g. `2.1.0` for stable
   builds, or `sha-4f99686` for dev)
 - **Views** dropdown — switch between **Events** and **Logs** views
 - **Settings** dropdown — open **App Settings** or **Bluetooth Adapters**

--- a/bluetooth_audio_manager_dev/DOCS.md
+++ b/bluetooth_audio_manager_dev/DOCS.md
@@ -44,7 +44,7 @@ Bluetooth integration (used for BLE sensors, beacons, etc.):
 The header bar contains:
 
 - **Build info pill** — shows the version string (e.g. `sha-4f99686` for dev
-  builds, or a semver like `0.2.5` for stable)
+  builds, or a semver like `2.1.0` for stable)
 - **Views** dropdown — switch between **Events** and **Logs** views
 - **Settings** dropdown — open **App Settings** or **Bluetooth Adapters**
 - **Connection status** badge — shows the WebSocket state: *Connected*,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -67,14 +67,21 @@ ha-bluetooth-audio-manager/
 │       ├── api.py                       # REST endpoints
 │       ├── events.py                    # EventBus + WebSocket pub/sub
 │       ├── log_handler.py              # Log streaming to UI
-│       └── static/                      # Frontend (HTML/JS/CSS)
+│       └── static/                      # Frontend (HTML/JS/CSS + Swagger UI)
+├── tests/                               # Hardware-free test suite
+│   ├── test_*.py                        # Python unit tests
+│   ├── js/                              # Frontend escaping tests (bare node)
+│   └── e2e/                             # Browser tests (Playwright, local only)
 ├── docker/                              # Container build
 │   ├── Dockerfile                       # Alpine 3.20 image
 │   ├── requirements.txt                 # Python dependencies
 │   └── rootfs/etc/                      # s6-overlay init scripts
 ├── bluetooth_audio_manager/             # HA add-on manifest (stable)
 ├── bluetooth_audio_manager_dev/         # HA add-on manifest (dev channel)
-├── .github/workflows/build.yaml         # CI/CD pipeline
+├── .github/workflows/
+│   ├── build.yaml                       # Multi-arch image build & publish
+│   ├── test.yaml                        # Unit tests + frontend escaping tests
+│   └── link-device-issues.yaml          # Issue automation
 └── docs/                                # Documentation
 ```
 
@@ -348,7 +355,7 @@ Two methods:
 
 **File:** `src/bt_audio_manager/persistence/store.py`
 
-Devices are stored in `/data/paired_devices.json`:
+Devices are stored in `/config/paired_devices.json` — the `addon_config` mapping, which survives a reinstall. (`/data/paired_devices.json` is the legacy location and is migrated on first read; the Supervisor deletes `/data/` unconditionally on uninstall, which is why the store moved out of it.)
 
 ```json
 {
@@ -414,7 +421,11 @@ Backoff multiplier is 1.5× with jitter to prevent thundering herd.
 - Device exists in the persistent store
 - Disconnect was **not** user-initiated (user disconnects set `_suppress_reconnect`)
 
-On app startup, `reconnect_all()` attempts to reconnect every stored device that has `auto_connect=true`.
+The global setting is checked in one place, `_reconnect_enabled()`, both **before** scheduling work and **again after every backoff sleep**. Turning Auto Reconnect off therefore stops attempts already in flight, rather than letting a loop that is mid-backoff run to completion.
+
+On app startup, `reconnect_all()` reconnects stored devices with `auto_connect=true` **only when the global setting is enabled**. With Auto Reconnect off, startup reconnection is skipped entirely, so a speaker deliberately left free for a phone stays free across add-on updates, HA restarts, and host reboots (#281).
+
+This never disturbs a device that is already connected: BlueZ holds the Bluetooth link across an add-on restart, and the reconnect loop skips anything already reporting connected. The setting governs whether the add-on *initiates* a connection — it never tears one down.
 
 ---
 
@@ -498,7 +509,23 @@ A single-page application built with vanilla JavaScript, Bootstrap 5, and Font A
 - **Events** — Real-time MPRIS/AVRCP event log
 - **Logs** — Live application log with filtering
 
+Plus a separate **API Reference** page (`docs.html`, served at `/api/docs`) — a self-hosted Swagger UI over `openapi.yaml`, reachable from Settings.
+
 **WebSocket reconnection:** On disconnect, shows a banner with elapsed time and attempts reconnection with randomized backoff (1–10 seconds).
+
+### Output escaping (security-relevant)
+
+The UI builds markup with template literals and assigns it to `innerHTML`. Device names and adapter aliases come from Bluetooth advertisements, so they are chosen by whoever is in radio range — every interpolation of device-derived data is an injection site. Three helpers cover the three contexts, and using the wrong one is a vulnerability rather than a style issue:
+
+| Helper | Use in | Notes |
+| ------ | ------ | ----- |
+| `escapeHtml()` | Text positions | Sets `textContent`, reads `innerHTML`. Escapes `&`, `<`, `>` — **not quotes**. Not safe in an attribute. |
+| `escapeAttr()` | Quoted attribute values | Also escapes `"` and `'`. |
+| `safeJsString()` | JS string literals inside an `onclick=` attribute | Escapes backslashes, quotes and HTML-significant characters; coerces non-strings. |
+
+Values interpolated as JS numbers or booleans are coerced (`Number()`, `!!`) rather than passed through.
+
+`tests/js/test_escaping.js` asserts these contracts in CI, and `tests/e2e/test_xss_browser.py` verifies them in a real browser locally. See [tests/README.md](../tests/README.md).
 
 ---
 
@@ -510,9 +537,11 @@ Three-tier configuration with fallback:
 
 | Priority | Source | File | Managed By |
 |----------|--------|------|------------|
-| 1 | Runtime settings | `/data/settings.json` | Web UI (no restart needed) |
+| 1 | Runtime settings | `/config/settings.json` | Web UI (no restart needed) |
 | 2 | HA options | `/data/options.json` | HA config page (restart needed) |
 | 3 | Defaults | In-memory | Hardcoded |
+
+Runtime settings live under `addon_config` (`/config/`) so they survive a reinstall; `/data/settings.json` is the legacy path and is migrated on first read. `options.json` stays in `/data/` because the Supervisor injects it there.
 
 **HA options** only controls `log_level`. All other settings (adapter, reconnect params, scan duration) are managed through the web UI and persisted in `settings.json`.
 
@@ -527,9 +556,11 @@ The `bt_adapter` setting supports three formats:
 
 ## CI/CD Pipeline
 
-**File:** `.github/workflows/build.yaml`
+**Files:** `.github/workflows/build.yaml` (image build & publish) and
+`.github/workflows/test.yaml` (unit tests + frontend escaping tests)
 
-See [docs/ci-workflow.md](ci-workflow.md) for detailed CI documentation.
+See [docs/ci-workflow.md](ci-workflow.md) for detailed CI documentation, and
+[tests/README.md](../tests/README.md) for what the suite does and does not cover.
 
 ### Dual-Channel Release
 

--- a/docs/ci-workflow.md
+++ b/docs/ci-workflow.md
@@ -2,17 +2,24 @@
 
 ## Overview
 
-The project uses a single GitHub Actions workflow (`build.yaml`) that builds multi-arch
-Docker images for both stable and dev channels. Images are published to GHCR as
-multi-arch manifests (not per-arch packages).
+Two GitHub Actions workflows carry the pipeline:
+
+- **`build.yaml`** — builds multi-arch Docker images for both stable and dev channels.
+  Images are published to GHCR as multi-arch manifests (not per-arch packages).
+- **`test.yaml`** — runs the hardware-free test suite. Independent of `build.yaml`,
+  so a test failure does not block an image build and vice versa.
+
+(`link-device-issues.yaml` handles issue automation and is not part of the build path.)
 
 ## Triggers
 
 | Event | Scope | What runs |
 |---|---|---|
-| Push to `dev` | Source changes only | Dev build + dev manifest + version bump PR |
+| Push to `dev` | Source changes only | Dev build + dev manifest + version bump PR, and tests |
+| Push to `main` | Source changes only | Tests only (no image build — see below) |
 | Push `v*` tag | Always | Stable build + stable manifest |
-| PR to `main` | Source changes only | Stable validation build (no push) |
+| PR to `main` | Source changes only | Stable validation build (no push), and tests |
+| PR to `dev` | Source changes only | Tests |
 
 ### paths-ignore
 
@@ -24,6 +31,33 @@ Both `push` and `pull_request` triggers skip builds when only non-build files ch
 
 The `pull_request` trigger additionally ignores `bluetooth_audio_manager_dev/**` to
 prevent the automated dev version bump PRs from triggering wasteful validation builds.
+
+`test.yaml` uses the same ignore list on both triggers, plus `docs/**` — documentation
+changes never affect test outcomes.
+
+## Test Workflow (`test.yaml`)
+
+A single `Unit tests` job on `ubuntu-latest`:
+
+1. **Install libpulse** — `pulsectl` `dlopen()`s `libpulse.so.0` at import time, so
+   anything importing `bt_audio_manager.audio` or `.manager` needs it present
+2. **Install dependencies** — `docker/requirements.txt` plus PyYAML (the image gets
+   YAML from the `py3-yaml` apk package, since there is no musl wheel for armv7)
+3. **Byte-compile** `src` and `tests`
+4. **Assert every module imports** — tests skip themselves when libpulse is missing so
+   contributors on macOS aren't blocked; this step makes sure a skip can never
+   silently hide a broken import
+5. **Run unit tests** — `python -m unittest discover -s tests -t . -v`
+6. **Run frontend escaping tests** — `node tests/js/test_escaping.js`, guarding the
+   output escaping in `web/static/app.js` against XSS via device names. Bare `node`,
+   no toolchain or dependencies
+
+The Playwright browser suite (`tests/e2e/`) is deliberately **not** in CI — it needs a
+~95 MB browser download. It self-skips when Playwright is absent and is run locally
+when touching escaping or device rendering. See [tests/README.md](../tests/README.md).
+
+There is no Bluetooth adapter, D-Bus, or PulseAudio server in CI, so the suite covers
+decisions made *about* hardware data rather than hardware behaviour itself.
 
 ## Build Flow
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -30,7 +30,7 @@ add-on, where typed C# minimal-API endpoints let the framework generate the spec
 
 [`aiohttp-pydantic`](https://pypi.org/project/aiohttp-pydantic/) 3.0.1 (May 2026) is the closest
 Python equivalent. Requires Python >= 3.12 and aiohttp >= 3.10 — both already satisfied here
-(3.12 and 3.14.1). Its `aiohttp_pydantic.oas` sub-app generates the spec from annotations, and
+(3.12 and 3.14.3). Its `aiohttp_pydantic.oas` sub-app generates the spec from annotations, and
 function-based handlers are supported via `@inject_params`, so no class-based view rewrite.
 
 Handlers would become:

--- a/docs/test-roadmap.md
+++ b/docs/test-roadmap.md
@@ -1,6 +1,6 @@
 # Test Roadmap
 
-Status: **Planned** — backlog of tests to add on top of the suite introduced in PR #290. Each item is independently actionable; work top-down.
+Status: **In progress** — backlog of tests to add on top of the suite introduced in PR #290. Each item is independently actionable; work top-down. Completed items are struck through and kept for context rather than deleted.
 
 Non-test backlog items live in [roadmap.md](roadmap.md).
 
@@ -11,8 +11,12 @@ CI has no Bluetooth adapter, no D-Bus, and no PulseAudio server. Everything here
 Run the suite with:
 
 ```bash
-PYTHONPATH=src python -m unittest discover -s tests -t . -v
+PYTHONPATH=src python -m unittest discover -s tests -t . -v   # Python
+node tests/js/test_escaping.js                                # frontend escaping
 ```
+
+Both run in CI. The Playwright browser suite (`tests/e2e/`) is local-only — see
+[tests/README.md](../tests/README.md).
 
 ## The habit that matters most
 
@@ -27,7 +31,7 @@ Every issue with a log attached is a potential test fixture. That is the cheapes
 ### 1. `get_audio_devices()` end-to-end with a fake ObjectManager
 
 **Where:** new `tests/test_get_audio_devices.py`
-**Depends on:** #288 (assert the post-fix behaviour, so land it there or after)
+**Unblocked** — #288 shipped in v2.1.0, so assert the post-fix behaviour
 
 `tests/test_discovery_filter.py` covers the helpers, but not the filter itself — the code that broke in #286 and that #288 changes. It consumes a `GetManagedObjects()` dict and returns a device list, which is entirely fakeable.
 
@@ -88,17 +92,18 @@ Also worth: 404 on unknown device, 400 on malformed body, and that error respons
 
 **Why:** small, and the WebSocket path is load-bearing for the whole UI.
 
-### 6. Reconnect backoff schedule
+### ~~6. Reconnect backoff schedule~~ — **done in #298**
 
-**Where:** new `tests/test_reconnect.py`
-**May need a small refactor**
+**Where:** `tests/test_reconnect.py`
 
-`src/bt_audio_manager/reconnect.py`. If the delay schedule is a pure function of attempt count, assert the curve and the ceiling directly. If it is interleaved with `asyncio.sleep`, extract the schedule first.
+Landed alongside the fix for #281. The tests assert the *decision* rather than the delay curve: given the global setting and service state, does a reconnect task get created? Covers startup, the disconnect path, the `_reconnect_enabled()` truth table, and that the device store isn't read at all when the setting is off.
+
+The backoff curve itself is still untested — it remains interleaved with `asyncio.sleep`, so asserting it would need the schedule extracted into a pure function first. Worth doing only if the curve changes.
 
 ### 7. `MPDManager._daemon_env()`
 
 **Where:** extend `tests/test_mpd_config.py`
-**Depends on:** #289
+**Unblocked** — #289 shipped in v2.1.0
 
 Assert `PULSE_PROP_module-stream-restore.id` is set to the per-speaker value, and that the rest of the inherited environment survives (`PATH`, `PULSE_SERVER`).
 
@@ -126,12 +131,15 @@ Compare `bluetooth_audio_manager/config.yaml` and `bluetooth_audio_manager_dev/c
 
 **Why:** the Supervisor reads add-on metadata from `main`, and the dev build workflow syncs `config.yaml` and `apparmor.txt` from dev→main. Any *new* metadata file added to the dev slug must be added to that sync step too — a drift this test would surface. See #215.
 
-### 10. Frontend helpers
+### 10. Frontend helpers — **partly done in #307**
 
-**Where:** new `tests/js/`, run with `node --test`
-**Only if the JS surface is worth a second toolchain**
+**Where:** `tests/js/test_escaping.js`
 
-`profileLabels()` and the device-card rendering helpers in `web/static/app.js` — mainly the UUID→label mapping.
+The question "is the JS surface worth a second toolchain?" was answered by an actual XSS bug: `escapeHtml()` was being used inside a quoted attribute, where it does not escape quotes, so a device name of `x" onmouseover="…` landed an event handler in the panel. Device names come from Bluetooth advertisements, which makes this attacker-controlled input.
+
+The answer was **no second toolchain** — the suite runs on bare `node` with no `package.json`, no dependencies, and no test framework, so it costs one CI step. It extracts the helpers and `buildDeviceCard()` out of `app.js` by name and renders cards from hostile input. `tests/e2e/test_xss_browser.py` backs it with a real browser locally.
+
+**Still open:** `profileLabels()` and the UUID→label mapping, the original subject of this item. Same harness, no new infrastructure needed.
 
 ---
 


### PR DESCRIPTION
Full pass over every markdown file in the repo. Most of it was drift, but **three claims were actively wrong** — the kind that cost someone an afternoon rather than just reading as out of date.

## Wrong, now fixed

**1. `architecture.md` documented the pre-#298 reconnect behaviour**

> On app startup, `reconnect_all()` attempts to reconnect every stored device that has `auto_connect=true`.

That was precisely the bug #298 fixed. Anyone reading this while debugging Auto Reconnect would conclude the setting is ignored at startup by design. Replaced with the real semantics, including that the setting is re-checked after every backoff sleep (so it cancels in-flight attempts) and that already-connected devices are never torn down.

**2. `architecture.md` had the storage paths wrong**

It documented `/data/paired_devices.json` and `/data/settings.json`. Both moved to `/config/` (the `addon_config` mapping). This one matters: the Supervisor deletes `/data/` unconditionally on uninstall, and surviving that was the entire reason for the move — so the doc pointed at the exact location the data is *not* kept. Verified `options.json` does correctly stay in `/data/`, since the Supervisor injects it there.

**3. `ci-workflow.md` claimed there was only one workflow**

> The project uses a single GitHub Actions workflow (`build.yaml`)

`test.yaml` has existed since #290.

## Brought current

- **`architecture.md`** — project layout was missing `tests/` entirely and listed one workflow; added the Swagger UI page; new **Output Escaping** section documenting which of the three helpers (`escapeHtml` / `escapeAttr` / `safeJsString`) belongs in which context. That table exists because picking the wrong one is a vulnerability, not a style question — which is exactly how #307 happened.
- **`ci-workflow.md`** — trigger table now covers `test.yaml`; new section on what the test job runs step by step, and why the Playwright suite is deliberately excluded from CI.
- **`test-roadmap.md`** — item 6 done in #298; item 10 partly done in #307, with the remaining `profileLabels()` work still called out so it isn't lost; items 1 and 7 marked unblocked now that #288/#289 have shipped; run commands include the JS suite.
- **`roadmap.md`** — aiohttp 3.14.1 → 3.14.3.
- **`DOCS.md` (both slugs)** — version examples were stale *and* disagreed with each other (`1.5.0` vs `0.2.5`).

## Verification

- **0 broken relative links** across all 12 markdown files (scripted check)
- Reconnect claims checked against `_reconnect_enabled()` in `reconnect.py` — 3 call sites, matching "before scheduling and after every sleep"
- Storage paths checked against `store.py` / `config.py` constants
- Suite still green: 90 Python tests (2 skipped) + JS escaping tests

Docs-only, so `build.yaml` skips it via `paths-ignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)