### PR TITLE
docs: correct stale claims for the 2.1.0 release

### DIFF
--- a/bluetooth_audio_manager/DOCS.md
+++ b/bluetooth_audio_manager/DOCS.md
@@ -43,7 +43,7 @@ Bluetooth integration (used for BLE sensors, beacons, etc.):
 
 The header bar contains:
 
-- **Build info pill** — shows the version string (e.g. `1.5.0` for stable
+- **Build info pill** — shows the version string (e.g. `2.1.0` for stable
   builds, or `sha-4f99686` for dev)
 - **Views** dropdown — switch between **Events** and **Logs** views
 - **Settings** dropdown — open **App Settings** or **Bluetooth Adapters**

--- a/bluetooth_audio_manager_dev/DOCS.md
+++ b/bluetooth_audio_manager_dev/DOCS.md
@@ -44,7 +44,7 @@ Bluetooth integration (used for BLE sensors, beacons, etc.):
 The header bar contains:
 
 - **Build info pill** — shows the version string (e.g. `sha-4f99686` for dev
-  builds, or a semver like `0.2.5` for stable)
+  builds, or a semver like `2.1.0` for stable)
 - **Views** dropdown — switch between **Events** and **Logs** views
 - **Settings** dropdown — open **App Settings** or **Bluetooth Adapters**
 - **Connection status** badge — shows the WebSocket state: *Connected*,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -67,14 +67,18 @@ ha-bluetooth-audio-manager/
 │       ├── api.py                       # REST endpoints
 │       ├── events.py                    # EventBus + WebSocket pub/sub
 │       ├── log_handler.py              # Log streaming to UI
-│       └── static/                      # Frontend (HTML/JS/CSS)
+│       └── static/                      # Frontend (HTML/JS/CSS + Swagger UI)
+├── tests/                               # Hardware-free test suite (Python)
 ├── docker/                              # Container build
 │   ├── Dockerfile                       # Alpine 3.20 image
 │   ├── requirements.txt                 # Python dependencies
 │   └── rootfs/etc/                      # s6-overlay init scripts
 ├── bluetooth_audio_manager/             # HA add-on manifest (stable)
 ├── bluetooth_audio_manager_dev/         # HA add-on manifest (dev channel)
-├── .github/workflows/build.yaml         # CI/CD pipeline
+├── .github/workflows/
+│   ├── build.yaml                       # Multi-arch image build & publish
+│   ├── test.yaml                        # Unit tests
+│   └── link-device-issues.yaml          # Issue automation
 └── docs/                                # Documentation
 ```
 
@@ -348,7 +352,7 @@ Two methods:
 
 **File:** `src/bt_audio_manager/persistence/store.py`
 
-Devices are stored in `/data/paired_devices.json`:
+Devices are stored in `/config/paired_devices.json` — the `addon_config` mapping, which survives a reinstall. (`/data/paired_devices.json` is the legacy location and is migrated on first read; the Supervisor deletes `/data/` unconditionally on uninstall, which is why the store moved out of it.)
 
 ```json
 {
@@ -414,7 +418,11 @@ Backoff multiplier is 1.5× with jitter to prevent thundering herd.
 - Device exists in the persistent store
 - Disconnect was **not** user-initiated (user disconnects set `_suppress_reconnect`)
 
-On app startup, `reconnect_all()` attempts to reconnect every stored device that has `auto_connect=true`.
+The global setting is checked in one place, `_reconnect_enabled()`, both **before** scheduling work and **again after every backoff sleep**. Turning Auto Reconnect off therefore stops attempts already in flight, rather than letting a loop that is mid-backoff run to completion.
+
+On app startup, `reconnect_all()` reconnects stored devices with `auto_connect=true` **only when the global setting is enabled**. With Auto Reconnect off, startup reconnection is skipped entirely, so a speaker deliberately left free for a phone stays free across add-on updates, HA restarts, and host reboots (#281).
+
+This never disturbs a device that is already connected: BlueZ holds the Bluetooth link across an add-on restart, and the reconnect loop skips anything already reporting connected. The setting governs whether the add-on *initiates* a connection — it never tears one down.
 
 ---
 
@@ -498,6 +506,8 @@ A single-page application built with vanilla JavaScript, Bootstrap 5, and Font A
 - **Events** — Real-time MPRIS/AVRCP event log
 - **Logs** — Live application log with filtering
 
+Plus a separate **API Reference** page (`docs.html`, served at `/api/docs`) — a self-hosted Swagger UI over `openapi.yaml`, reachable from Settings.
+
 **WebSocket reconnection:** On disconnect, shows a banner with elapsed time and attempts reconnection with randomized backoff (1–10 seconds).
 
 ---
@@ -510,9 +520,11 @@ Three-tier configuration with fallback:
 
 | Priority | Source | File | Managed By |
 |----------|--------|------|------------|
-| 1 | Runtime settings | `/data/settings.json` | Web UI (no restart needed) |
+| 1 | Runtime settings | `/config/settings.json` | Web UI (no restart needed) |
 | 2 | HA options | `/data/options.json` | HA config page (restart needed) |
 | 3 | Defaults | In-memory | Hardcoded |
+
+Runtime settings live under `addon_config` (`/config/`) so they survive a reinstall; `/data/settings.json` is the legacy path and is migrated on first read. `options.json` stays in `/data/` because the Supervisor injects it there.
 
 **HA options** only controls `log_level`. All other settings (adapter, reconnect params, scan duration) are managed through the web UI and persisted in `settings.json`.
 
@@ -527,9 +539,11 @@ The `bt_adapter` setting supports three formats:
 
 ## CI/CD Pipeline
 
-**File:** `.github/workflows/build.yaml`
+**Files:** `.github/workflows/build.yaml` (image build & publish) and
+`.github/workflows/test.yaml` (unit tests)
 
-See [docs/ci-workflow.md](ci-workflow.md) for detailed CI documentation.
+See [docs/ci-workflow.md](ci-workflow.md) for detailed CI documentation, and
+[tests/README.md](../tests/README.md) for what the suite does and does not cover.
 
 ### Dual-Channel Release
 

--- a/docs/ci-workflow.md
+++ b/docs/ci-workflow.md
@@ -2,17 +2,24 @@
 
 ## Overview
 
-The project uses a single GitHub Actions workflow (`build.yaml`) that builds multi-arch
-Docker images for both stable and dev channels. Images are published to GHCR as
-multi-arch manifests (not per-arch packages).
+Two GitHub Actions workflows carry the pipeline:
+
+- **`build.yaml`** — builds multi-arch Docker images for both stable and dev channels.
+  Images are published to GHCR as multi-arch manifests (not per-arch packages).
+- **`test.yaml`** — runs the hardware-free test suite. Independent of `build.yaml`,
+  so a test failure does not block an image build and vice versa.
+
+(`link-device-issues.yaml` handles issue automation and is not part of the build path.)
 
 ## Triggers
 
 | Event | Scope | What runs |
 |---|---|---|
-| Push to `dev` | Source changes only | Dev build + dev manifest + version bump PR |
+| Push to `dev` | Source changes only | Dev build + dev manifest + version bump PR, and tests |
+| Push to `main` | Source changes only | Tests only (no image build — see below) |
 | Push `v*` tag | Always | Stable build + stable manifest |
-| PR to `main` | Source changes only | Stable validation build (no push) |
+| PR to `main` | Source changes only | Stable validation build (no push), and tests |
+| PR to `dev` | Source changes only | Tests |
 
 ### paths-ignore
 
@@ -24,6 +31,27 @@ Both `push` and `pull_request` triggers skip builds when only non-build files ch
 
 The `pull_request` trigger additionally ignores `bluetooth_audio_manager_dev/**` to
 prevent the automated dev version bump PRs from triggering wasteful validation builds.
+
+`test.yaml` uses the same ignore list on both triggers, plus `docs/**` — documentation
+changes never affect test outcomes.
+
+## Test Workflow (`test.yaml`)
+
+A single `Unit tests` job on `ubuntu-latest`:
+
+1. **Install libpulse** — `pulsectl` `dlopen()`s `libpulse.so.0` at import time, so
+   anything importing `bt_audio_manager.audio` or `.manager` needs it present
+2. **Install dependencies** — `docker/requirements.txt` plus PyYAML (the image gets
+   YAML from the `py3-yaml` apk package, since there is no musl wheel for armv7)
+3. **Byte-compile** `src` and `tests`
+4. **Assert every module imports** — tests skip themselves when libpulse is missing so
+   contributors on macOS aren't blocked; this step makes sure a skip can never
+   silently hide a broken import
+5. **Run unit tests** — `python -m unittest discover -s tests -t . -v`
+
+There is no Bluetooth adapter, D-Bus, or PulseAudio server in CI, so the suite covers
+decisions made *about* hardware data rather than hardware behaviour itself. See
+[tests/README.md](../tests/README.md).
 
 ## Build Flow
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -30,7 +30,7 @@ add-on, where typed C# minimal-API endpoints let the framework generate the spec
 
 [`aiohttp-pydantic`](https://pypi.org/project/aiohttp-pydantic/) 3.0.1 (May 2026) is the closest
 Python equivalent. Requires Python >= 3.12 and aiohttp >= 3.10 — both already satisfied here
-(3.12 and 3.14.1). Its `aiohttp_pydantic.oas` sub-app generates the spec from annotations, and
+(3.12 and 3.14.3). Its `aiohttp_pydantic.oas` sub-app generates the spec from annotations, and
 function-based handlers are supported via `@inject_params`, so no class-based view rewrite.
 
 Handlers would become:

--- a/docs/test-roadmap.md
+++ b/docs/test-roadmap.md
@@ -1,6 +1,6 @@
 # Test Roadmap
 
-Status: **Planned** — backlog of tests to add on top of the suite introduced in PR #290. Each item is independently actionable; work top-down.
+Status: **In progress** — backlog of tests to add on top of the suite introduced in PR #290. Each item is independently actionable; work top-down. Completed items are struck through and kept for context rather than deleted.
 
 Non-test backlog items live in [roadmap.md](roadmap.md).
 
@@ -27,7 +27,7 @@ Every issue with a log attached is a potential test fixture. That is the cheapes
 ### 1. `get_audio_devices()` end-to-end with a fake ObjectManager
 
 **Where:** new `tests/test_get_audio_devices.py`
-**Depends on:** #288 (assert the post-fix behaviour, so land it there or after)
+**Unblocked** — #288 shipped in v2.1.0, so assert the post-fix behaviour
 
 `tests/test_discovery_filter.py` covers the helpers, but not the filter itself — the code that broke in #286 and that #288 changes. It consumes a `GetManagedObjects()` dict and returns a device list, which is entirely fakeable.
 
@@ -88,17 +88,18 @@ Also worth: 404 on unknown device, 400 on malformed body, and that error respons
 
 **Why:** small, and the WebSocket path is load-bearing for the whole UI.
 
-### 6. Reconnect backoff schedule
+### ~~6. Reconnect backoff schedule~~ — **done in #298**
 
-**Where:** new `tests/test_reconnect.py`
-**May need a small refactor**
+**Where:** `tests/test_reconnect.py`
 
-`src/bt_audio_manager/reconnect.py`. If the delay schedule is a pure function of attempt count, assert the curve and the ceiling directly. If it is interleaved with `asyncio.sleep`, extract the schedule first.
+Landed alongside the fix for #281. The tests assert the *decision* rather than the delay curve: given the global setting and service state, does a reconnect task get created? Covers startup, the disconnect path, the `_reconnect_enabled()` truth table, and that the device store isn't read at all when the setting is off.
+
+The backoff curve itself is still untested — it remains interleaved with `asyncio.sleep`, so asserting it would need the schedule extracted into a pure function first. Worth doing only if the curve changes.
 
 ### 7. `MPDManager._daemon_env()`
 
 **Where:** extend `tests/test_mpd_config.py`
-**Depends on:** #289
+**Unblocked** — #289 shipped in v2.1.0
 
 Assert `PULSE_PROP_module-stream-restore.id` is set to the per-speaker value, and that the rest of the inherited environment survives (`PATH`, `PULSE_SERVER`).
 
@@ -132,6 +133,8 @@ Compare `bluetooth_audio_manager/config.yaml` and `bluetooth_audio_manager_dev/c
 **Only if the JS surface is worth a second toolchain**
 
 `profileLabels()` and the device-card rendering helpers in `web/static/app.js` — mainly the UUID→label mapping.
+
+> Landed on `dev` after v2.1.0: an escaping test suite on bare `node` (no toolchain), added alongside an XSS fix. It ships to `main` with the next release.
 
 ---
 


### PR DESCRIPTION
Cherry-pick of the docs pass from #309, **restricted to what is actually true on `main` at v2.1.0**.

## Why this isn't a straight cherry-pick

#309 was written against `dev`, which carries the frontend escaping work (#307). `main` does not — it has no `escapeAttr()`, no `tests/js/`, no `tests/e2e/`, and no escaping step in `test.yaml`. Cherry-picking it wholesale would have traded one set of wrong docs for another.

So the following are **excluded** here and ship to `main` with the next release:

- the Output Escaping section in `architecture.md`
- `tests/js/` and `tests/e2e/` in the project layout
- the `node tests/js/test_escaping.js` CI step in `ci-workflow.md`
- test-roadmap item 10's "partly done in #307" status (left as the original proposal, with a forward-note that it landed on `dev`)

## What this fixes — three claims that were actively wrong

**1. The reconnect behaviour predates #298**

> On app startup, `reconnect_all()` attempts to reconnect every stored device that has `auto_connect=true`.

#298 shipped in 2.1.0 and changed exactly this. The doc described behaviour the released code no longer has, so anyone debugging Auto Reconnect would conclude the setting is ignored at startup by design.

**2. The storage paths were wrong**

Documented as `/data/paired_devices.json` and `/data/settings.json`; both are `/config/` (addon_config) in 2.1.0. This one has consequences — the Supervisor deletes `/data/` unconditionally on uninstall, and surviving that was the entire reason for the move, so the doc pointed at the one place the data deliberately isn't kept. (`options.json` genuinely does stay in `/data/` — verified, not assumed.)

**3. `ci-workflow.md` claimed a single workflow**

> The project uses a single GitHub Actions workflow (`build.yaml`)

`test.yaml` shipped in #290, part of 2.1.0.

## Also brought current

- `architecture.md` — project layout was missing `tests/` entirely and listed one workflow
- `ci-workflow.md` — full trigger table including `test.yaml`, plus a Test Workflow section documenting its 5 steps
- `test-roadmap.md` — item 6 done in #298; items 1 and 7 unblocked now #288/#289 have shipped
- `roadmap.md` — aiohttp 3.14.3
- `DOCS.md` (both slugs) — version examples were stale *and* disagreed with each other (`1.5.0` vs `0.2.5`)

## Verification

Every claim checked against **main's** tree, not dev's:

| Claim | Verified against |
| --- | --- |
| `/config/paired_devices.json` | `store.py:16` on main |
| `/config/settings.json` | `config.py:19` on main |
| `/data/options.json` | `config.py:18` on main |
| Reconnect honours the setting | `_reconnect_enabled` × 6 in `reconnect.py` on main |
| aiohttp 3.14.3 | `docker/requirements.txt` on main |
| Trigger table + 5 test steps | `test.yaml` on main |

Plus 0 broken relative links across all 12 markdown files.

## Note on the next promotion

`main` and `dev` now differ in these files, so the next `dev` → `main` merge will likely conflict in `architecture.md`, `ci-workflow.md` and `test-roadmap.md`. Resolution is always **take dev's side** — dev is the superset once the escaping work is released.

Docs-only, so `build.yaml` skips it via `paths-ignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)