### PR TITLE
ci: scope the test workflow's GITHUB_TOKEN to contents:read

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,6 +28,11 @@ jobs:
   test:
     name: Unit tests
     runs-on: ubuntu-latest
+    # The job only reads the repo — no packages, no PR writes. Every other
+    # workflow here scopes its token per-job; this one was missed, which
+    # CodeQL flagged on #306 (actions/missing-workflow-permissions).
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Actions the CodeQL finding that GitHub Advanced Security left on #306 — [`actions/missing-workflow-permissions`](https://github.com/scyto/ha-bluetooth-audio-manager/security/code-scanning/7), alert #7.

I merged #306 without reading that review comment. Fixing it now.

## The finding

> Actions job or workflow does not limit the permissions of the GITHUB_TOKEN. Consider setting an explicit permissions block, using the following as a minimal starting point: `{contents: read}`

It's valid. `test.yaml` was the **only** workflow in the repo without a permissions block, so its `GITHUB_TOKEN` fell back to the repository default instead of being scoped to what the job actually needs:

| Workflow | Permissions |
| --- | --- |
| `build.yaml` | per-job (5 blocks) — `contents: read` + `packages: write` / `pull-requests: write` where needed |
| `link-device-issues.yaml` | per-job |
| `test.yaml` | **none** ← flagged |

It was missed when the workflow was added in #290, not a deliberate choice.

## The fix

Job-level `permissions: contents: read`, matching the per-job style the other two workflows already use. The job checks out the repo and runs tests — it writes nothing, publishes nothing, and touches no PRs.

Verified the YAML still parses and the job retains all 8 steps.

## Note

The alert was raised against `main`, where `test.yaml` has the same gap. It will close when this reaches `main` with the next release — or say the word and I'll cherry-pick it across the way #310 did for the docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)